### PR TITLE
Configure to publish on Docker Hub at konard/sandbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/sandbox/issues/9
-Your prepared branch: issue-9-c1093a7a89f1
-Your prepared working directory: /tmp/gh-issue-solver-1768758509934
-
-Proceed.


### PR DESCRIPTION
## Summary

- Added Docker Hub publishing alongside GitHub Container Registry
- Docker images will be published to `konard/sandbox` on Docker Hub

## Changes

- Updated `.github/workflows/release.yml` to publish to both registries
- Added Docker Hub login step using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
- Multi-arch images (amd64 and arm64) are published to both registries
- Both registries receive the same tags: `latest`, SHA prefix, and date-based tags

## Test plan

- [ ] Verify CI workflow passes
- [ ] Repository owner needs to add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
- [ ] After secrets are configured and PR is merged, verify image appears at https://hub.docker.com/r/konard/sandbox

## Required secrets

Before the Docker Hub publishing will work, the following repository secrets must be configured:

1. **DOCKERHUB_USERNAME** - Docker Hub username (konard)
2. **DOCKERHUB_TOKEN** - Docker Hub access token (create at https://hub.docker.com/settings/security)

---

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)