### PR TITLE
fix: add expect to full-sandbox for Hive Mind compatibility (issue #64)

### DIFF
--- a/.changeset/add-expect-for-hive-mind-compatibility.md
+++ b/.changeset/add-expect-for-hive-mind-compatibility.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Add `expect` package to full-sandbox for Hive Mind compatibility (issue #64)

--- a/.changeset/add-hive-mind-ai-tools-playwright.md
+++ b/.changeset/add-hive-mind-ai-tools-playwright.md
@@ -1,5 +1,0 @@
----
-bump: minor
----
-
-Add AI coding agent CLIs, Hive Mind workflow utilities, and Playwright browser automation to full-sandbox (issue #64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -522,17 +522,8 @@ jobs:
           docker run --rm sandbox-test gh-setup-git-identity --version
           docker run --rm sandbox-test glab-setup-git-identity --version
 
-          # AI coding agent CLI tools (FR-6, issue #64)
-          docker run --rm sandbox-test claude --version
-          docker run --rm sandbox-test playwright --version
-
-          # Hive Mind workflow utilities (FR-7, issue #64)
-          docker run --rm sandbox-test gh-pull-all --help 2>/dev/null | head -1 || \
-            docker run --rm sandbox-test bash -c 'command -v gh-pull-all'
-          docker run --rm sandbox-test bash -c 'command -v gh-load-issue'
-          docker run --rm sandbox-test bash -c 'command -v gh-load-pull-request'
-          docker run --rm sandbox-test bash -c 'command -v gh-upload-log'
-          docker run --rm sandbox-test bash -c 'command -v start-command'
+          # expect (interactive automation tool, issue #64)
+          docker run --rm sandbox-test expect -v
 
           echo ""
           echo "=== PHP install method check ==="
@@ -1554,16 +1545,8 @@ jobs:
           docker run --rm "${IMAGE}" gh --version
           docker run --rm "${IMAGE}" glab --version
 
-          # AI coding agent CLI tools (FR-6, issue #64)
-          docker run --rm "${IMAGE}" claude --version
-          docker run --rm "${IMAGE}" playwright --version
-
-          # Hive Mind workflow utilities (FR-7, issue #64)
-          docker run --rm "${IMAGE}" bash -c 'command -v gh-pull-all'
-          docker run --rm "${IMAGE}" bash -c 'command -v gh-load-issue'
-          docker run --rm "${IMAGE}" bash -c 'command -v gh-load-pull-request'
-          docker run --rm "${IMAGE}" bash -c 'command -v gh-upload-log'
-          docker run --rm "${IMAGE}" bash -c 'command -v start-command'
+          # expect (interactive automation tool, issue #64)
+          docker run --rm "${IMAGE}" expect -v
 
           echo "=== All smoke tests passed for ${IMAGE} ==="
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -47,6 +47,7 @@ The Docker image MUST include:
 - LLVM
 - LLD linker
 - Assembly tools (GNU Assembler, NASM, LLVM-MC, FASM)
+- `expect` (interactive automation tool for scripting TTY interactions)
 
 ### FR-4: Multi-Architecture Support
 
@@ -58,52 +59,6 @@ The Docker image MUST be available for:
 ### FR-5: Container Registry
 
 The Docker image MUST be published to GitHub Container Registry (ghcr.io).
-
-### FR-6: AI Coding Agent CLI Tools
-
-The Docker image MUST include the following AI coding agent CLIs (installed as the `sandbox` user via `bun install -g`, preferring local over global installation):
-
-| Package | Purpose |
-|---------|---------|
-| `@anthropic-ai/claude-code` | Claude Code CLI (primary AI agent) |
-| `@openai/codex` | OpenAI Codex CLI |
-| `@qwen-code/qwen-code` | Qwen coding agent |
-| `@google/gemini-cli` | Google Gemini CLI |
-| `@github/copilot` | GitHub Copilot CLI |
-| `opencode-ai` | OpenCode AI agent |
-
-Optional packages that may not always be published — installation failures MUST be non-fatal (graceful skip):
-
-| Package | Purpose |
-|---------|---------|
-| `@link-assistant/hive-mind` | Hive Mind orchestrator |
-| `@link-assistant/claude-profiles` | Claude profile manager |
-| `@link-assistant/agent` | Agent runner |
-
-### FR-7: Hive Mind Workflow Utilities
-
-The Docker image MUST include the following workflow utilities (installed as the `sandbox` user via `bun install -g`):
-
-| Package | Purpose |
-|---------|---------|
-| `start-command` | Process start utility |
-| `gh-pull-all` | Clone all user repos |
-| `gh-load-issue` | Load GitHub issue |
-| `gh-load-pull-request` | Load GitHub PR |
-| `gh-upload-log` | Upload log to GitHub |
-
-### FR-8: Playwright Browser Automation
-
-The Docker image MUST include a full Playwright browser automation stack:
-
-- **Playwright OS system dependencies** (installed via `npx playwright@latest install-deps`)
-- **`@playwright/mcp@latest`** (npm global) — MCP server for Claude Code integration
-- **`@playwright/test@latest`** (npm global) — Playwright test CLI
-- **Browsers** (architecture-aware):
-  - All architectures: Chromium, Firefox, WebKit, Chromium Headless Shell
-  - x86_64 only: Chrome, Microsoft Edge (not available for ARM64)
-
-**Rationale**: The Hive Mind system uses Playwright for web interaction, screenshot capture, and UI testing within AI agent workflows.
 
 ## Non-Functional Requirements
 
@@ -215,15 +170,7 @@ All tools MUST prefer **local (user-specific) installation** over global (system
 - npm global packages: `npm install -g` → NVM-managed node prefix
 - System (apt) packages only when no local alternative exists
 
-**Rationale**: Local installation allows Docker image layers to be assembled via `COPY --from`, enabling parallel builds and easy portability between images.
-
-### C-6: Graceful Failure for Optional Packages (Issue #64)
-
-Some packages (especially `@link-assistant/*` packages) may not be published on NPM at all times. Their installation MUST:
-
-- Use `|| true` or equivalent to allow failure
-- Log the failure with a clear message
-- NOT abort the overall installation
+**Rationale**: Local installation allows Docker image layers to be assembled via `COPY --from`, enabling parallel builds and easy portability between images. Tools that require AI-specific packages (such as AI coding agents or workflow utilities) should be installed in images that inherit from the sandbox, rather than in the sandbox itself.
 
 ## Future Considerations
 
@@ -254,4 +201,4 @@ Before merging any CI/CD changes, verify:
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2026-01-16 | Initial requirements document |
-| 1.1 | 2026-03-05 | Add FR-6 (AI CLIs), FR-7 (workflow utilities), FR-8 (Playwright), C-5 (local-first), C-6 (graceful failures) per issue #64 |
+| 1.1 | 2026-03-05 | Add `expect` to FR-3, add C-5 (local-first installation policy) per issue #64 |

--- a/docs/case-studies/issue-64/CASE-STUDY.md
+++ b/docs/case-studies/issue-64/CASE-STUDY.md
@@ -2,7 +2,9 @@
 
 ## Executive Summary
 
-This case study documents a systematic comparison between the sandbox's `full-sandbox` Docker image and the requirements of the [hive-mind system](https://github.com/link-assistant/hive-mind/blob/main/scripts/ubuntu-24-server-install.sh). The analysis identifies missing tools and proposes concrete fixes.
+This case study documents a systematic comparison between the sandbox's `full-sandbox` Docker image and the general-purpose development tools required by the [hive-mind system](https://github.com/link-assistant/hive-mind/blob/main/scripts/ubuntu-24-server-install.sh). The analysis identifies what general-purpose (non-AI-specific) tools are missing from the sandbox.
+
+**Key finding**: The full-sandbox is already a superset of the general-purpose development stack that hive-mind requires. The only missing general-purpose tool is `expect`, used for interactive TTY scripting automation. AI-specific tools (Claude Code, Codex, Gemini CLI, Playwright, Hive Mind workflow utilities) belong in the hive-mind image, not in the universal sandbox.
 
 ---
 
@@ -12,10 +14,21 @@ This case study documents a systematic comparison between the sandbox's `full-sa
 
 Source: `https://github.com/link-assistant/hive-mind/blob/main/scripts/ubuntu-24-server-install.sh`
 
-The hive-mind install script installs the following tools as **`hive` user** (local/user-specific priority):
+The hive-mind install script installs two categories of tools:
+
+**A. General-purpose development tools** (also belong in the sandbox):
 
 | Category | Tool | Install Method | Location |
 |----------|------|----------------|----------|
+| System | `wget curl unzip zip git sudo ca-certificates gnupg` | apt | system |
+| System | `dotnet-sdk-8.0` | apt | system |
+| System | `build-essential` | apt | system |
+| System | `expect` | apt | system |
+| System | `screen` | apt | system |
+| System | `cmake clang llvm lld` | apt | system |
+| System | Python build deps (libssl-dev, zlib1g-dev, etc.) | apt | system |
+| System | GitHub CLI (`gh`) | apt (keyring) | system |
+| System | `bubblewrap` | apt | system |
 | Runtime | Node.js 20 | NVM | `~/.nvm` |
 | Runtime | Bun | Official installer | `~/.bun` |
 | Runtime | Deno | Official installer | `~/.deno` |
@@ -28,39 +41,28 @@ The hive-mind install script installs the following tools as **`hive` user** (lo
 | Prover | Lean 4 | elan | `~/.elan` |
 | Prover | Rocq/Coq | opam | `~/.opam` |
 | Package mgr | Homebrew | Official installer | `/home/linuxbrew` |
-| System | dotnet-sdk-8.0 | apt | system |
-| System | cmake, clang, llvm, lld | apt | system |
-| System | build-essential, git, gh, etc. | apt | system |
 
-**Global bun packages installed by hive-mind** (critical finding):
-```
-@link-assistant/hive-mind
-@link-assistant/claude-profiles
-@anthropic-ai/claude-code
-@openai/codex
-@qwen-code/qwen-code
-@google/gemini-cli
-@github/copilot
-opencode-ai
-@link-assistant/agent
-start-command
-gh-setup-git-identity
-gh-pull-all
-gh-load-issue
-gh-load-pull-request
-gh-upload-log
-```
+**B. AI/Hive-Mind-specific tools** (belong in the hive-mind image, NOT in the sandbox):
 
-**Playwright** (full browser automation stack):
-- Playwright OS system dependencies (via `npx playwright@latest install-deps`)
-- `@playwright/mcp@latest` (global npm)
-- `@playwright/test@latest` (global npm)
-- Browsers: chromium, chrome, firefox, webkit, msedge (arch-dependent), chromium-headless-shell
-- Claude MCP configuration
+| Category | Tool | Install Method |
+|----------|------|----------------|
+| AI agent | `@anthropic-ai/claude-code` | `bun install -g` |
+| AI agent | `@openai/codex` | `bun install -g` |
+| AI agent | `@qwen-code/qwen-code` | `bun install -g` |
+| AI agent | `@google/gemini-cli` | `bun install -g` |
+| AI agent | `@github/copilot` | `bun install -g` |
+| AI agent | `opencode-ai` | `bun install -g` |
+| Hive Mind | `@link-assistant/hive-mind` | `bun install -g` |
+| Hive Mind | `@link-assistant/claude-profiles` | `bun install -g` |
+| Hive Mind | `@link-assistant/agent` | `bun install -g` |
+| Workflow | `start-command` | `bun install -g` |
+| Workflow | `gh-pull-all` | `bun install -g` |
+| Workflow | `gh-load-issue` | `bun install -g` |
+| Workflow | `gh-load-pull-request` | `bun install -g` |
+| Workflow | `gh-upload-log` | `bun install -g` |
+| Browser automation | Playwright (OS deps + browsers + MCP) | npm + npx |
 
-### 1.2 Full-Sandbox Current State
-
-The full-sandbox assembles from individual language images and adds:
+### 1.2 Full-Sandbox Current State (Before This Fix)
 
 | Category | Tool | Status |
 |----------|------|--------|
@@ -84,116 +86,104 @@ The full-sandbox assembles from individual language images and adds:
 | System | Assembly (nasm, fasm) | ✅ Present (bonus) |
 | System | build-essential, git, gh | ✅ Present |
 | System | screen | ✅ Present (essentials) |
+| System | bubblewrap | ✅ Present |
 | Global pkg | gh-setup-git-identity | ✅ Present (essentials) |
 | Global pkg | glab-setup-git-identity | ✅ Present (essentials, bonus) |
-| **Global pkg** | **@anthropic-ai/claude-code** | ❌ **MISSING** |
-| **Global pkg** | **@openai/codex** | ❌ **MISSING** |
-| **Global pkg** | **@qwen-code/qwen-code** | ❌ **MISSING** |
-| **Global pkg** | **@google/gemini-cli** | ❌ **MISSING** |
-| **Global pkg** | **@github/copilot** | ❌ **MISSING** |
-| **Global pkg** | **opencode-ai** | ❌ **MISSING** |
-| **Global pkg** | **@link-assistant/hive-mind** | ❌ **MISSING** |
-| **Global pkg** | **@link-assistant/claude-profiles** | ❌ **MISSING** |
-| **Global pkg** | **@link-assistant/agent** | ❌ **MISSING** |
-| **Global pkg** | **start-command** | ❌ **MISSING** |
-| **Global pkg** | **gh-pull-all** | ❌ **MISSING** |
-| **Global pkg** | **gh-load-issue** | ❌ **MISSING** |
-| **Global pkg** | **gh-load-pull-request** | ❌ **MISSING** |
-| **Global pkg** | **gh-upload-log** | ❌ **MISSING** |
-| **Browser automation** | **Playwright (OS deps + browsers + MCP)** | ❌ **MISSING** |
+| **System** | **expect** | ❌ **MISSING** |
 
 ---
 
 ## 2. Root Cause Analysis
 
-### 2.1 Why Are These Tools Missing?
+### 2.1 Architecture Principle: Separation of Concerns
 
-The sandbox was originally designed as a **programming language runtime environment** — providing compilers, interpreters, and build tools. The Hive Mind system extends this to include an **AI coding agent workflow** layer, which requires:
+The `full-sandbox` is designed as a **universal development sandbox** — a base image for software development across many languages. It is intentionally not AI-specific.
 
-1. **AI CLI tools** (`claude-code`, `codex`, `gemini-cli`, etc.) — These are the agent frontends that enable AI-assisted coding.
-2. **Workflow utilities** (`gh-pull-all`, `gh-load-issue`, etc.) — These are hive-mind–specific tools for managing GitHub workflows within the AI agent loop.
-3. **Browser automation** (Playwright) — Required for web interaction, screenshot capture, and UI testing within AI agent workflows.
+The Hive Mind system is an AI coding agent orchestrator that **inherits from the sandbox** and adds:
+- AI agent CLI frontends
+- Workflow automation utilities
+- Playwright browser automation
 
-### 2.2 Installation Strategy: Local Over Global
+This separation means:
+- **Sandbox** → universal programming environment (language runtimes, compilers, tools)
+- **Hive Mind image** → extends sandbox + adds AI tools on top
 
-Per `REQUIREMENTS.md` and the hive-mind script philosophy: **user-specific (local) installation is prioritized over global installation** for portability between Docker images. This means:
+Violating this boundary by adding AI tools to the sandbox would:
+1. Bloat the universal sandbox with AI-specific software
+2. Create a maintenance burden when AI tool versions change
+3. Make the sandbox less useful for non-AI use cases
 
-- Bun global packages: `bun install -g <pkg>` → installs to `~/.bun/bin/`
-- npm global packages: `npm install -g <pkg>` → installs to NVM-managed node prefix
-- System (apt) packages are only used when no local alternative exists
+### 2.2 The One True Gap: `expect`
+
+The `expect` tool is a **general-purpose interactive automation utility** — it allows scripts to programmatically interact with programs that require user input (TTY interaction scripting). This is not AI-specific; it's a standard development and operations tool.
+
+Hive-mind installs `expect` in its main apt section alongside other essential tools (`wget`, `curl`, `git`, etc.), confirming it's considered a general-purpose tool needed for the development environment.
 
 ---
 
 ## 3. Gap Analysis Summary
 
-### Missing: AI Coding Agent CLI Tools
+### General-Purpose Tools: Missing From Sandbox
 
-These tools are required for the Hive Mind system to function as an AI coding environment:
+| # | Tool | Category | Severity | Fix |
+|---|------|----------|----------|-----|
+| 1 | `expect` | System (apt) | Low | Add to Dockerfile apt-get install |
 
-| Package | Purpose | Install Method |
-|---------|---------|----------------|
-| `@anthropic-ai/claude-code` | Claude Code CLI (primary AI agent) | `bun install -g` |
-| `@openai/codex` | OpenAI Codex CLI | `bun install -g` |
-| `@qwen-code/qwen-code` | Qwen coding agent | `bun install -g` |
-| `@google/gemini-cli` | Google Gemini CLI | `bun install -g` |
-| `@github/copilot` | GitHub Copilot CLI | `bun install -g` |
-| `opencode-ai` | OpenCode AI agent | `bun install -g` |
+### AI-Specific Tools: Out-of-Scope for Sandbox
 
-### Missing: Hive Mind Workflow Tools
+These tools are installed by hive-mind but are **intentionally NOT added** to the universal sandbox. Hive Mind inherits from the sandbox and adds them on top:
 
-| Package | Purpose | Install Method |
-|---------|---------|----------------|
-| `@link-assistant/hive-mind` | Hive Mind orchestrator | `bun install -g` |
-| `@link-assistant/claude-profiles` | Claude profile manager | `bun install -g` |
-| `@link-assistant/agent` | Agent runner | `bun install -g` |
-| `start-command` | Process start utility | `bun install -g` |
-| `gh-pull-all` | Clone all user repos | `bun install -g` |
-| `gh-load-issue` | Load GitHub issue | `bun install -g` |
-| `gh-load-pull-request` | Load GitHub PR | `bun install -g` |
-| `gh-upload-log` | Upload log to GitHub | `bun install -g` |
+| Tool | Reason Not in Sandbox |
+|------|----------------------|
+| `@anthropic-ai/claude-code` | AI-agent specific, not general development |
+| `@openai/codex` | AI-agent specific |
+| `@google/gemini-cli` | AI-agent specific |
+| `@qwen-code/qwen-code` | AI-agent specific |
+| `@github/copilot` | AI-agent specific |
+| `opencode-ai` | AI-agent specific |
+| `@link-assistant/hive-mind` | Hive Mind orchestrator — belongs in hive-mind image |
+| `start-command`, `gh-pull-all`, etc. | Hive Mind workflow tools — belongs in hive-mind image |
+| Playwright + browsers | Browser automation for AI workflows — belongs in hive-mind image |
 
-### Missing: Playwright Browser Automation
+### Things Full-Sandbox Has That Hive-Mind Does Not (Bonuses)
 
-| Component | Purpose |
-|-----------|---------|
-| Playwright OS dependencies | System libs required by browser engines |
-| `@playwright/mcp` | Playwright MCP server for Claude Code |
-| `@playwright/test` | Playwright test CLI |
-| Chromium browser | Primary headless browser |
-| Firefox browser | Secondary browser |
-| WebKit browser | Safari-compatible browser |
-| Chrome/Edge (x86_64 only) | Additional browsers |
-| Chromium Headless Shell | CI-optimized headless browser |
+The sandbox is already a superset of hive-mind's general-purpose stack:
+
+| Tool | Present In |
+|------|-----------|
+| Kotlin (SDKMAN) | Full-sandbox only |
+| Ruby (rbenv) | Full-sandbox only |
+| Swift | Full-sandbox only |
+| R (`r-base`) | Full-sandbox only |
+| Assembly (nasm, fasm) | Full-sandbox only |
+| GitLab CLI (`glab`) + `glab-setup-git-identity` | Full-sandbox only |
 
 ---
 
 ## 4. Solution
 
-### 4.1 Approach
+### 4.1 Changes Made
 
-Add the missing tools to `ubuntu/24.04/full-sandbox/install.sh` and `Dockerfile`:
+1. **`ubuntu/24.04/full-sandbox/Dockerfile`**: Add `expect` to the apt-get install block
+2. **`ubuntu/24.04/full-sandbox/install.sh`**: Add `expect` install to the system packages section
+3. **`REQUIREMENTS.md`**: Document `expect` in FR-3 (Development Tools); add C-5 (local-first installation policy)
+4. **`.github/workflows/release.yml`**: Add `expect -v` check to CI tests
 
-1. **Global bun/npm packages** — Install as `sandbox` user in the user-setup section of `install.sh`
-2. **Playwright** — Install OS deps as root, then browsers as `sandbox` user
-3. Update `REQUIREMENTS.md` to document the new requirements
-4. Follow the existing pattern of local (user-space) installation
+### 4.2 Design Decision: Where AI Tools Belong
 
-### 4.2 Key Design Decisions
+The Hive Mind system should:
+1. Use the sandbox image as its base (`FROM konard/sandbox:latest`)
+2. Add its AI CLIs (`claude-code`, `codex`, `gemini-cli`, etc.) in the hive-mind Dockerfile
+3. Add Playwright and browser automation in the hive-mind Dockerfile
+4. Add its workflow utilities (`gh-pull-all`, `gh-load-issue`, etc.) in the hive-mind Dockerfile
 
-- **Graceful failures**: Some packages (like `@link-assistant/hive-mind`) may not be published yet; use `|| true` and skip on errors
-- **Architecture-aware browsers**: Chrome/Edge not available on ARM64; install Chromium instead
-- **Local priority**: All packages installed to user's home directory, not system-wide
-- **Playwright MCP config**: Added to Claude CLI config if available
+This way, the sandbox remains a clean, universal development environment that any project can build upon.
 
 ---
 
 ## 5. References
 
 - [Hive Mind Install Script](https://github.com/link-assistant/hive-mind/blob/main/scripts/ubuntu-24-server-install.sh)
-- [Playwright Installation Docs](https://playwright.dev/docs/intro)
-- [Playwright MCP](https://github.com/microsoft/playwright-mcp)
-- [Claude Code npm package](https://www.npmjs.com/package/@anthropic-ai/claude-code)
-- [OpenAI Codex](https://www.npmjs.com/package/@openai/codex)
-- [Google Gemini CLI](https://www.npmjs.com/package/@google/gemini-cli)
+- [expect(1) man page](https://linux.die.net/man/1/expect)
 - [Issue #44: PHP installation strategy](../../case-studies/issue-44/CASE-STUDY.md)
 - [Issue #62: CI toolchain tests](../../case-studies/issue-62/CASE-STUDY.md)

--- a/ubuntu/24.04/full-sandbox/Dockerfile
+++ b/ubuntu/24.04/full-sandbox/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update -y && \
       r-base \
       cmake clang llvm lld \
       nasm \
+      expect \
       bubblewrap && \
     # FASM only available on x86_64
     if [ "$(uname -m)" = "x86_64" ]; then apt-get install -y fasm; fi && \
@@ -189,60 +190,6 @@ ENV RBENV_ROOT="/home/sandbox/.rbenv"
 ENV PATH="/home/linuxbrew/.linuxbrew/opt/php@8.3/bin:/home/linuxbrew/.linuxbrew/opt/php@8.3/sbin:/home/linuxbrew/.linuxbrew/bin:/home/sandbox/.pyenv/bin:/home/sandbox/.pyenv/shims:/home/sandbox/.rbenv/bin:/home/sandbox/.rbenv/shims:/home/sandbox/.swift/usr/bin:/home/sandbox/.elan/bin:/home/sandbox/.opam/default/bin:/home/sandbox/.cargo/bin:/home/sandbox/.deno/bin:/home/sandbox/.bun/bin:/home/sandbox/.go/bin:/home/sandbox/.go/path/bin:${PATH}"
 
 SHELL ["/bin/bash", "-c"]
-
-# --- Install AI coding agent CLIs, Hive Mind workflow utilities, and Playwright (issue #64) ---
-# These are installed as sandbox user (local/user-specific, FR-6, FR-7, FR-8)
-# following the local-first installation policy (C-5).
-RUN set -e && \
-    # Load NVM to get node/npm/npx
-    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
-    nvm use 20 2>/dev/null || true && \
-    \
-    # Install AI coding agent CLIs via bun (FR-6)
-    # Some packages may not be published; use || true for graceful failures (C-6)
-    for pkg in "@anthropic-ai/claude-code" "@openai/codex" "@qwen-code/qwen-code" "@google/gemini-cli" "@github/copilot" "opencode-ai"; do \
-      echo "[*] Installing $pkg..." && \
-      bun install -g "$pkg" 2>&1 | head -5 || echo "[!] $pkg install failed (may not be published) - continuing"; \
-    done && \
-    \
-    # Install optional Hive Mind packages (graceful failure, C-6)
-    for pkg in "@link-assistant/hive-mind" "@link-assistant/claude-profiles" "@link-assistant/agent"; do \
-      echo "[*] Installing $pkg (optional)..." && \
-      bun install -g "$pkg" 2>&1 | head -3 || echo "[i] $pkg not available - skipping"; \
-    done && \
-    \
-    # Install Hive Mind workflow utilities (FR-7)
-    for pkg in "start-command" "gh-pull-all" "gh-load-issue" "gh-load-pull-request" "gh-upload-log"; do \
-      echo "[*] Installing $pkg..." && \
-      bun install -g "$pkg" 2>&1 | head -5 || echo "[!] $pkg install failed - continuing"; \
-    done && \
-    \
-    # Install Playwright OS dependencies as root (browser system libraries)
-    NPX_PATH="$(command -v npx 2>/dev/null || true)" && \
-    if [ -n "$NPX_PATH" ]; then \
-      NODE_BIN_DIR="$(dirname "$(command -v node 2>/dev/null || echo /usr/bin/node)")" && \
-      sudo env "PATH=$NODE_BIN_DIR:$PATH" "$NPX_PATH" -y playwright@latest install-deps 2>&1 | grep -v "^$" || \
-      echo "[!] Playwright install-deps had issues"; \
-    fi && \
-    \
-    # Install Playwright npm packages (FR-8)
-    npm install -g @playwright/mcp@latest --no-fund --silent 2>&1 | tail -3 || echo "[!] @playwright/mcp install failed" && \
-    npm install -g @playwright/test@latest --no-fund --silent 2>&1 | tail -3 || echo "[!] @playwright/test install failed" && \
-    \
-    # Install Playwright browsers (architecture-aware, FR-8)
-    ARCH="$(uname -m)" && \
-    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-      BROWSERS="chromium firefox webkit"; \
-    else \
-      BROWSERS="chromium chrome firefox webkit msedge"; \
-    fi && \
-    for browser in $BROWSERS; do \
-      echo "[*] Installing Playwright browser: $browser..." && \
-      npx -y playwright@latest install "$browser" --with-deps 2>&1 | grep -E "(Downloading|complete|Error)" | head -5 || \
-      echo "[!] Playwright browser $browser installation skipped or failed"; \
-    done && \
-    npx -y playwright@latest install chromium-headless-shell --with-deps 2>&1 | head -3 || echo "[i] chromium-headless-shell skipped" && \
-    echo "[✓] AI tools and Playwright installation complete"
 
 # Opam environment variables for Rocq/Coq theorem prover
 ENV OPAM_SWITCH_PREFIX="/home/sandbox/.opam/default"

--- a/ubuntu/24.04/full-sandbox/install.sh
+++ b/ubuntu/24.04/full-sandbox/install.sh
@@ -58,6 +58,11 @@ log_info "Installing R statistical language..."
 maybe_sudo apt install -y r-base
 log_success "R language installed"
 
+# expect (interactive automation tool, used by hive-mind workflows)
+log_info "Installing expect..."
+maybe_sudo apt install -y expect
+log_success "expect installed"
+
 # Note: Common build dependencies (build-essential, libssl-dev, zlib1g-dev,
 # libyaml-dev, etc.) are already installed in the essentials-sandbox layer.
 
@@ -414,124 +419,6 @@ if ! command_exists swift; then
   fi
 fi
 
-# --- AI Coding Agent CLI Tools and Hive Mind Workflow Utilities ---
-log_step "Installing AI coding agent CLI tools and Hive Mind workflow utilities"
-
-# Ensure NVM/Node and Bun are loaded
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-nvm use 20 2>/dev/null || true
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
-# Install AI coding agent CLIs via bun (local/user-specific, FR-6)
-# These are required for Hive Mind compatibility (issue #64)
-# Some packages may not always be published; failures are non-fatal (C-6)
-AI_PACKAGES="@anthropic-ai/claude-code @openai/codex @qwen-code/qwen-code @google/gemini-cli @github/copilot opencode-ai"
-OPTIONAL_PACKAGES="@link-assistant/hive-mind @link-assistant/claude-profiles @link-assistant/agent"
-
-log_info "Installing AI coding agent CLIs (required)..."
-for pkg in $AI_PACKAGES; do
-  log_info "Installing $pkg..."
-  bun install -g "$pkg" 2>&1 | grep -v "^$" | head -5 || {
-    log_warning "Failed to install $pkg (may not be published yet) - continuing"
-  }
-done
-
-log_info "Installing optional Hive Mind packages (graceful failure)..."
-for pkg in $OPTIONAL_PACKAGES; do
-  log_info "Installing $pkg..."
-  bun install -g "$pkg" 2>&1 | grep -v "^$" | head -5 || {
-    log_note "$pkg not available (may not be published yet) - skipping"
-  }
-done
-
-# Install Hive Mind workflow utilities via bun (FR-7)
-log_info "Installing Hive Mind workflow utilities..."
-WORKFLOW_PACKAGES="start-command gh-pull-all gh-load-issue gh-load-pull-request gh-upload-log"
-for pkg in $WORKFLOW_PACKAGES; do
-  log_info "Installing $pkg..."
-  bun install -g "$pkg" 2>&1 | grep -v "^$" | head -5 || {
-    log_warning "Failed to install $pkg - continuing"
-  }
-done
-
-log_success "AI coding agent CLIs and workflow utilities installation complete"
-
-# --- Playwright Browser Automation (FR-8) ---
-log_step "Installing Playwright browser automation"
-
-# Update npm to latest before installing Playwright
-npm install -g npm@latest --no-fund --silent 2>&1 | tail -1 || true
-
-# Install Playwright MCP server (for Claude Code integration)
-log_info "Installing Playwright MCP server..."
-npm install -g @playwright/mcp@latest --no-fund --silent 2>&1 | tail -3 || {
-  log_warning "npm install -g @playwright/mcp@latest failed"
-}
-
-# Install Playwright CLI (needed for install-deps and browser install)
-log_info "Installing Playwright CLI..."
-npm install -g @playwright/test@latest --no-fund --silent 2>&1 | tail -3 || {
-  log_warning "npm install -g @playwright/test@latest failed"
-}
-
-# Install Playwright OS dependencies (system libraries for browsers)
-# Run install-deps as root via sudo, using the node binary from the user's NVM
-log_info "Installing Playwright OS dependencies (requires sudo)..."
-NPX_PATH="$(command -v npx 2>/dev/null || true)"
-if [ -n "$NPX_PATH" ]; then
-  NODE_BIN_DIR="$(dirname "$(command -v node 2>/dev/null || echo /usr/bin/node)")"
-  sudo env "PATH=$NODE_BIN_DIR:$PATH" "$NPX_PATH" -y playwright@latest install-deps 2>&1 | grep -v "^$" || {
-    log_warning "Playwright install-deps had issues (some system libraries may be missing)"
-  }
-  log_success "Playwright OS dependencies installed"
-else
-  log_warning "npx not found - skipping Playwright OS system deps"
-fi
-
-# Install Playwright browsers (architecture-aware)
-log_info "Installing Playwright browsers..."
-ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-  BROWSERS_TO_INSTALL="chromium firefox webkit"
-  log_note "Running on arm64: Chrome and Edge not available, using Chromium instead"
-else
-  BROWSERS_TO_INSTALL="chromium chrome firefox webkit msedge"
-fi
-
-log_note "Installing: $BROWSERS_TO_INSTALL"
-for browser in $BROWSERS_TO_INSTALL; do
-  log_info "Installing Playwright browser: $browser..."
-  npx -y playwright@latest install "$browser" --with-deps 2>&1 | grep -E "(Downloading|downloaded|complete|error|Error)" | head -5 || {
-    log_warning "Playwright browser $browser installation failed or skipped"
-  }
-done
-
-# Install chromium headless shell (CI-optimized)
-log_info "Installing chromium headless shell..."
-npx -y playwright@latest install chromium-headless-shell --with-deps 2>&1 | grep -E "(Downloading|downloaded|complete|error|Error)" | head -5 || {
-  log_note "chromium-headless-shell installation skipped"
-}
-
-# Verify Playwright installation
-if command_exists playwright; then
-  log_success "Playwright: $(playwright --version)"
-else
-  log_warning "Playwright CLI not found in PATH"
-fi
-
-# Configure Playwright MCP for Claude CLI (if claude is available)
-if command_exists claude; then
-  log_info "Configuring Playwright MCP for Claude CLI..."
-  claude mcp remove playwright 2>/dev/null || true
-  claude mcp add playwright -s user -- npx -y @playwright/mcp@latest --isolated --headless --no-sandbox --timeout-action=600000 --viewport-size 1920x1080 2>/dev/null || {
-    log_note "Claude MCP config will be available after: claude mcp add playwright -s user -- npx -y @playwright/mcp@latest --isolated --headless --no-sandbox"
-  }
-fi
-
-log_success "Playwright browser automation installation complete"
-
 # --- Installation Summary ---
 log_step "Installation Summary"
 
@@ -558,26 +445,6 @@ command_exists brew && log_success "Homebrew: $(brew --version 2>/dev/null | hea
 command_exists php && log_success "PHP: $(php --version 2>/dev/null | head -n1)" || true
 command_exists perl && log_success "Perl: $(perl --version | head -n 2 | tail -n 1 | sed 's/^[[:space:]]*//')" || true
 command_exists opam && log_success "Opam: $(opam --version)" || true
-
-echo ""
-echo "AI Coding Agent CLI Tools:"
-command_exists claude && log_success "Claude Code: $(claude --version 2>/dev/null | head -n1)" || log_warning "Claude Code: not found"
-command_exists codex && log_success "OpenAI Codex: installed" || log_warning "OpenAI Codex: not found"
-command_exists gemini && log_success "Gemini CLI: installed" || log_warning "Gemini CLI: not found"
-command_exists opencode && log_success "OpenCode: installed" || log_warning "OpenCode: not found"
-
-echo ""
-echo "Playwright:"
-command_exists playwright && log_success "Playwright CLI: $(playwright --version)" || log_warning "Playwright CLI: not found"
-PLAYWRIGHT_CACHE="$HOME/.cache/ms-playwright"
-for browser in chromium firefox webkit chromium_headless_shell; do
-  BROWSER_DIR=$(ls -d "$PLAYWRIGHT_CACHE/${browser}"* 2>/dev/null | head -1 || true)
-  if [ -n "$BROWSER_DIR" ] && [ -d "$BROWSER_DIR" ]; then
-    log_success "Playwright browser: $browser"
-  else
-    log_warning "Playwright browser not in cache: $browser"
-  fi
-done
 
 echo ""
 EOF_FULL_SETUP


### PR DESCRIPTION
Fixes #64

## What Was Found

A systematic comparison of the [hive-mind install script](https://github.com/link-assistant/hive-mind/blob/main/scripts/ubuntu-24-server-install.sh) against the full-sandbox Docker image was performed.

**Architecture clarification**: The full-sandbox is a **universal development sandbox**, not an AI-specific one. The Hive Mind system should inherit from the sandbox and add its own AI-specific tools on top. This separation of concerns keeps the sandbox clean and reusable.

**Key finding**: The full-sandbox is already a superset of hive-mind's general-purpose development stack. The only missing general-purpose tool is `expect`.

## What Was Missing (General-Purpose Tools Only)

| Tool | Category | Status Before This PR |
|------|----------|-----------------------|
| `expect` | Interactive TTY automation (apt) | ❌ Missing |

## What Is NOT in Scope (AI-Specific, Belongs in Hive Mind Image)

| Category | Tools |
|----------|-------|
| AI coding agent CLIs | `@anthropic-ai/claude-code`, `@openai/codex`, `@google/gemini-cli`, etc. |
| Hive Mind workflow utilities | `start-command`, `gh-pull-all`, `gh-load-issue`, etc. |
| Browser automation | Playwright + browsers + MCP |

These tools should be installed by the hive-mind image on top of the sandbox, not in the sandbox itself.

## Full-Sandbox vs Hive-Mind: Already a Superset

The sandbox already provides everything hive-mind needs for the general-purpose layer — and more:

| Tool | Hive-Mind Needs | Full-Sandbox |
|------|-----------------|--------------|
| Node.js 20, Bun, Deno | ✅ | ✅ |
| Python (pyenv), Go, Rust | ✅ | ✅ |
| Java 21 (SDKMAN), PHP 8.3 | ✅ | ✅ |
| Perl (Perlbrew), Lean 4, Rocq | ✅ | ✅ |
| dotnet-sdk-8.0, cmake, clang, llvm | ✅ | ✅ |
| git, gh, screen, bubblewrap | ✅ | ✅ |
| Kotlin, Ruby, Swift, R, Assembly | ❌ not needed | ✅ (bonus) |
| GitLab CLI (glab) | ❌ not needed | ✅ (bonus) |

## Changes Made

- `ubuntu/24.04/full-sandbox/Dockerfile`: Add `expect` to apt-get install block
- `ubuntu/24.04/full-sandbox/install.sh`: Add `expect` to system packages section
- `REQUIREMENTS.md`: Add `expect` to FR-3 (Development Tools); add C-5 (local-first installation policy with inheritance pattern note)
- `.github/workflows/release.yml`: Add `expect -v` test; remove AI-tool tests from PR tests and smoke tests
- `docs/case-studies/issue-64/CASE-STUDY.md`: Rewritten to document correct findings and the separation of concerns between sandbox and hive-mind

## Case Study

Full gap analysis: [`docs/case-studies/issue-64/CASE-STUDY.md`](docs/case-studies/issue-64/CASE-STUDY.md)