### PR TITLE
fix(dind): default exec sessions to box user

### DIFF
--- a/.changeset/fix-dind-user.md
+++ b/.changeset/fix-dind-user.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fix dind-box images so `docker exec` opens as the `box` user while the dind entrypoint still starts dockerd through scoped passwordless sudo.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
           fi
 
           # dind-box changes (issue #80)
-          if echo "$CHANGED_FILES" | grep -qE '^ubuntu/24\.04/dind/'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(ubuntu/24\.04/dind/|docs/dind/|tests/dind/)'; then
             echo "dind=true" >> $GITHUB_OUTPUT
           else
             echo "dind=false" >> $GITHUB_OUTPUT
@@ -394,6 +394,9 @@ jobs:
           elif [ "${{ steps.changes.outputs.version }}" = "true" ]; then
             echo "result=true" >> $GITHUB_OUTPUT
             echo "Build triggered by: VERSION file changes"
+          elif [ "${{ steps.image-changes.outputs.dind }}" = "true" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+            echo "Build triggered by: dind docs/tests changes"
           else
             echo "result=false" >> $GITHUB_OUTPUT
             echo "No build needed: no relevant changes detected"
@@ -876,6 +879,20 @@ jobs:
           docker run --rm --entrypoint=/bin/bash "$IMG" -c 'docker compose version'
           docker run --rm --entrypoint=/bin/bash "$IMG" -c 'cat /etc/box/variant'
           echo "=== ${IMG} smoke tests passed ==="
+
+      - name: Test documented dind examples
+        if: matrix.variant == 'js'
+        env:
+          DIND_IMAGE: box-dind-js
+          DIND_WAIT_SECONDS: "60"
+        run: |
+          set -e
+          echo "=== Testing documented dind examples against ${DIND_IMAGE} ==="
+          tests/dind/example-basic-docker-ps.sh
+          tests/dind/example-commit-cycle.sh
+          tests/dind/example-sudoers-extension.sh
+          tests/dind/example-storage-driver-vfs.sh
+          echo "=== Documented dind examples passed ==="
 
   # --- Aggregator: single status check for branch protection ---
   # GitHub branch protection rules can require this one job to pass instead of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -855,7 +855,19 @@ jobs:
         run: |
           set -e
           IMG="box-dind-${{ matrix.variant }}"
-          echo "=== Testing ${IMG} (CLI presence only - no privileged mode in PR CI) ==="
+          echo "=== Testing ${IMG} (no privileged mode in PR CI) ==="
+          # Regression check for issue #88: docker exec and entrypoint-bypassed
+          # shells use the image's configured USER, so dind variants must keep
+          # Config.User aligned with the regular box images.
+          CONFIG_USER=$(docker inspect --format '{{.Config.User}}' "$IMG")
+          if [ "$CONFIG_USER" != "box" ]; then
+            echo "Expected ${IMG} Config.User to be box, got '${CONFIG_USER:-<empty>}'"
+            exit 1
+          fi
+          docker run --rm --entrypoint=/bin/bash "$IMG" -c 'test "$(whoami)" = box'
+          docker run --rm --entrypoint=/bin/bash "$IMG" -c 'test "$HOME" = /home/box'
+          docker run --rm --entrypoint=/bin/bash "$IMG" -c 'sudo -n /usr/bin/dockerd --version'
+
           # Verify Docker CLI, dockerd binary, buildx and compose plugins are present.
           # We do NOT start dockerd here because GitHub-hosted runners disallow --privileged.
           docker run --rm --entrypoint=/bin/bash "$IMG" -c 'docker --version'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T13:43:52.556Z for PR creation at branch issue-88-e338036f5bf2 for issue https://github.com/link-foundation/box/issues/88

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T13:43:52.556Z for PR creation at branch issue-88-e338036f5bf2 for issue https://github.com/link-foundation/box/issues/88

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ curl -fsSL https://raw.githubusercontent.com/link-foundation/box/main/ubuntu/24.
 
 ### Docker Hub - dind-box (Docker-in-Docker variants, issue #80)
 
-Each row below has the same toolchain as its non-dind sibling **plus** a working Docker Engine (Docker CLI + dockerd + containerd + Buildx + Compose v2). The default is nested Docker-in-Docker — each container has its own daemon, so `docker ps -a` from inside the container only lists containers it created. See the [security model](#docker-in-docker-security-model) section below and [docs/case-studies/issue-80](docs/case-studies/issue-80/CASE-STUDY.md).
+Each row below has the same toolchain as its non-dind sibling **plus** a working Docker Engine (Docker CLI + dockerd + containerd + Buildx + Compose v2). The default is nested Docker-in-Docker — each container has its own daemon, so `docker ps -a` from inside the container only lists containers it created. See the [security model](#docker-in-docker-security-model) section below, the [dind usage guide](docs/dind/USAGE.md), and [docs/case-studies/issue-80](docs/case-studies/issue-80/CASE-STUDY.md).
 
 | Image | Multi-arch | AMD64 | ARM64 |
 |-------|------------|-------|-------|
@@ -218,6 +218,7 @@ Each row below has the same toolchain as its non-dind sibling **plus** a working
 > - **Recommended secure invocation:** [`docker run --runtime=sysbox-runc konard/box-dind`](https://github.com/nestybox/sysbox) — Sysbox is a drop-in OCI runtime that runs system containers without `--privileged` and without exposing host devices.
 > - **Do NOT bind-mount `/var/run/docker.sock`.** That gives the container root on the host ([Quarkslab](https://blog.quarkslab.com/why-is-exposing-the-docker-socket-a-really-bad-idea.html), [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html)) and breaks the per-box `docker ps` scoping property.
 > - **Storage:** the inner daemon writes to `/var/lib/docker` inside the container by default. For persistence, mount a volume: `-v box-dind-data:/var/lib/docker`.
+> - **Usage examples:** see [`docs/dind/USAGE.md`](docs/dind/USAGE.md). Its examples are backed by executable tests under `tests/dind/`.
 
 See [docs/case-studies/issue-80/CASE-STUDY.md](docs/case-studies/issue-80/CASE-STUDY.md) for the full design and threat model.
 

--- a/docs/dind/USAGE.md
+++ b/docs/dind/USAGE.md
@@ -1,0 +1,198 @@
+# dind-box Usage
+
+The `-dind` images are regular box images with Docker Engine added. They keep the
+same user-facing default as the non-dind images: `docker exec` opens as `box`
+with `HOME=/home/box`. The entrypoint starts the inner `dockerd` with a scoped
+passwordless sudo rule, then hands off to the normal box entrypoint.
+
+The runnable examples in this document live under `tests/dind/` and are executed
+by pull request CI against the locally built `box-dind-js` image.
+
+## Runtime Flags
+
+Use one of these host-side runtime modes when you need the inner Docker daemon:
+
+```bash
+docker run -d --privileged --name box-dind konard/box-dind sleep infinity
+```
+
+```bash
+docker run -d --runtime=sysbox-runc --name box-dind konard/box-dind sleep infinity
+```
+
+`--privileged` is the default Docker-in-Docker mode. Sysbox is the preferred
+mode for shared hosts when the `sysbox-runc` runtime is installed, because it is
+designed for system containers without exposing the host Docker socket.
+
+Without a runtime that lets the inner daemon create namespaces, mounts, and
+cgroups, the container shell can still start but Docker commands normally fail:
+
+```text
+[dind-entrypoint] WARN: dockerd did not become ready within 30s
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock
+```
+
+The dockerd log path is controlled by `DIND_LOG_FILE` and defaults to
+`/var/log/dockerd.log`.
+
+## Basic Docker Use
+
+This example starts the image, waits for the entrypoint to bring up the inner
+daemon, and checks that `docker exec` still lands as `box`:
+
+```bash
+docker run -d --privileged --name box-dind konard/box-dind sleep infinity
+
+until docker exec box-dind docker info >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker exec box-dind whoami
+docker exec box-dind docker ps
+docker exec box-dind pgrep -x dockerd
+```
+
+CI runs the same flow as an executable example:
+
+```bash
+DIND_IMAGE=box-dind-js tests/dind/example-basic-docker-ps.sh
+```
+
+## Runtime Environment
+
+The entrypoint supports these environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DIND_STORAGE_DRIVER` | auto | Override the inner dockerd storage driver. |
+| `DIND_DATA_ROOT` | `/var/lib/docker` | Override the inner dockerd data root. |
+| `DIND_LOG_FILE` | `/var/log/dockerd.log` | Write dockerd logs to this path. |
+| `DIND_WAIT_SECONDS` | `30` | Wait this many seconds for dockerd readiness. |
+| `DIND_SKIP_DAEMON` | `0` | Set to `1` to skip dockerd startup. |
+
+Use a named volume when the inner Docker state should survive container removal:
+
+```bash
+docker volume create box-dind-data
+docker run -d --privileged \
+  -v box-dind-data:/var/lib/docker \
+  --name box-dind \
+  konard/box-dind sleep infinity
+```
+
+## Commit Cycles
+
+`DIND_SKIP_DAEMON=1` is useful for setup containers where you want to install or
+configure files before committing an image:
+
+```bash
+docker run -d --name box-dind-setup \
+  -e DIND_SKIP_DAEMON=1 \
+  konard/box-dind sleep infinity
+
+docker exec box-dind-setup bash -lc 'echo setup complete'
+docker commit --change 'ENV DIND_SKIP_DAEMON=0' box-dind-setup my-box-dind
+docker run -d --privileged --name my-box-dind my-box-dind sleep infinity
+```
+
+The `--change 'ENV DIND_SKIP_DAEMON=0'` reset is intentional. Docker commit
+preserves container environment, so committing a setup container that has
+`DIND_SKIP_DAEMON=1` can produce an image that silently skips dockerd on later
+runs.
+
+CI covers this behavior here:
+
+```bash
+DIND_IMAGE=box-dind-js tests/dind/example-commit-cycle.sh
+```
+
+## Sudoers Contract
+
+The image installs `/etc/sudoers.d/box-dind` with passwordless sudo for only the
+root operations required by the DIND entrypoint:
+
+```text
+/usr/bin/dockerd
+/usr/bin/chgrp
+/usr/bin/chmod
+/usr/bin/mkdir
+```
+
+Do not broaden this file into general passwordless sudo. If a derived image
+needs one additional root capability, add a separate sudoers file with the exact
+absolute binary path and validate it with `visudo`:
+
+```dockerfile
+FROM konard/box-dind
+
+USER root
+RUN printf '%s\n' 'box ALL=(root) NOPASSWD: /usr/bin/id' \
+      | install -m 0440 -o root -g root /dev/stdin /etc/sudoers.d/box-dind-example-id && \
+    visudo -cf /etc/sudoers.d/box-dind-example-id >/dev/null
+
+USER box
+ENV HOME=/home/box
+```
+
+CI builds and verifies that pattern:
+
+```bash
+DIND_IMAGE=box-dind-js tests/dind/example-sudoers-extension.sh
+```
+
+## Storage Driver
+
+When `DIND_STORAGE_DRIVER` is empty, the entrypoint chooses `overlay2` if the
+host advertises overlay support, then `fuse-overlayfs`, then `vfs`.
+
+Use the default for normal developer workflows. Pin `DIND_STORAGE_DRIVER=vfs`
+when the host cannot run overlay-backed nested Docker reliably or when you need
+the most conservative compatibility mode. The trade-off is disk use and
+performance: `vfs` copies whole filesystem trees instead of using overlay
+copy-on-write layers.
+
+```bash
+docker run -d --privileged \
+  -e DIND_STORAGE_DRIVER=vfs \
+  --name box-dind-vfs \
+  konard/box-dind sleep infinity
+```
+
+CI verifies the forced `vfs` path:
+
+```bash
+DIND_IMAGE=box-dind-js tests/dind/example-storage-driver-vfs.sh
+```
+
+## Host Prerequisites
+
+The host kernel and Docker runtime must allow the inner daemon to create the
+mounts, namespaces, cgroups, and networking state that Docker Engine needs.
+In practice:
+
+- Use `--privileged` for the standard nested Docker mode, or install and use
+  `sysbox-runc` for the Sysbox mode.
+- Do not bind-mount `/var/run/docker.sock` from the host. That switches the
+  model to Docker-outside-of-Docker, exposes host Docker control, and breaks the
+  per-container Docker view.
+- Ensure enough disk is available for `/var/lib/docker`, or mount a volume there.
+- If dockerd does not become ready, inspect `docker logs <container>` and the
+  configured `DIND_LOG_FILE` inside the container before changing timeouts.
+
+## Local Example Runner
+
+To run the same examples CI runs against a local image:
+
+```bash
+docker build -f ubuntu/24.04/dind/Dockerfile \
+  --build-arg BASE_IMAGE=konard/box-js:latest \
+  -t box-dind-js .
+
+DIND_IMAGE=box-dind-js tests/dind/example-basic-docker-ps.sh
+DIND_IMAGE=box-dind-js tests/dind/example-commit-cycle.sh
+DIND_IMAGE=box-dind-js tests/dind/example-sudoers-extension.sh
+DIND_IMAGE=box-dind-js tests/dind/example-storage-driver-vfs.sh
+```
+
+Set `DIND_KEEP_CONTAINERS=1` while debugging to keep the temporary containers
+and images after a failing example.

--- a/docs/dind/USAGE.md
+++ b/docs/dind/USAGE.md
@@ -142,8 +142,11 @@ DIND_IMAGE=box-dind-js tests/dind/example-sudoers-extension.sh
 
 ## Storage Driver
 
-When `DIND_STORAGE_DRIVER` is empty, the entrypoint chooses `overlay2` if the
-host advertises overlay support, then `fuse-overlayfs`, then `vfs`.
+When `DIND_STORAGE_DRIVER` is empty, the entrypoint tries `overlay2` if the
+host advertises overlay support, then `fuse-overlayfs` if it is installed, then
+`vfs`. If a candidate makes `dockerd` exit before it is ready, the entrypoint
+logs the failure and retries the next candidate. This covers nested runtimes
+where overlay support is visible but overlay-backed Docker still cannot start.
 
 Use the default for normal developer workflows. Pin `DIND_STORAGE_DRIVER=vfs`
 when the host cannot run overlay-backed nested Docker reliably or when you need

--- a/tests/dind/example-basic-docker-ps.sh
+++ b/tests/dind/example-basic-docker-ps.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/dind/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_docker
+
+container="${DIND_EXAMPLE_ID}-basic"
+
+log "starting ${DIND_IMAGE} as ${container}"
+run_dind_container "$container"
+wait_for_inner_docker "$container"
+assert_box_exec_user "$container"
+
+docker exec "$container" pgrep -x dockerd >/dev/null
+docker exec "$container" docker ps >/dev/null
+
+log "docker exec lands as box and inner docker ps works"

--- a/tests/dind/example-commit-cycle.sh
+++ b/tests/dind/example-commit-cycle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/dind/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_docker
+
+setup_container="${DIND_EXAMPLE_ID}-setup"
+leaky_image="${DIND_EXAMPLE_ID}-leaky"
+clean_image="${DIND_EXAMPLE_ID}-clean"
+leaky_container="${DIND_EXAMPLE_ID}-leaky-run"
+clean_container="${DIND_EXAMPLE_ID}-clean-run"
+
+register_image "$leaky_image"
+register_image "$clean_image"
+
+log "creating a setup container with DIND_SKIP_DAEMON=1"
+run_dind_container "$setup_container" -e DIND_SKIP_DAEMON=1
+
+if docker exec "$setup_container" docker info >/dev/null 2>&1; then
+  fail "DIND_SKIP_DAEMON=1 should leave dockerd stopped in the setup container"
+fi
+
+docker commit "$setup_container" "$leaky_image" >/dev/null
+
+if ! docker image inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$leaky_image" | grep -qx 'DIND_SKIP_DAEMON=1'; then
+  fail "expected docker commit to preserve DIND_SKIP_DAEMON=1 in the leaky image"
+fi
+
+log "confirming the committed leaky image still skips dockerd"
+run_container_from_image "$leaky_container" "$leaky_image"
+sleep 2
+if docker exec "$leaky_container" docker info >/dev/null 2>&1; then
+  fail "the leaky committed image unexpectedly started dockerd"
+fi
+
+log "creating a cleaned image with DIND_SKIP_DAEMON reset to 0"
+docker commit --change 'ENV DIND_SKIP_DAEMON=0' "$setup_container" "$clean_image" >/dev/null
+
+run_container_from_image "$clean_container" "$clean_image"
+wait_for_inner_docker "$clean_container"
+assert_box_exec_user "$clean_container"
+
+log "commit cycle works when the setup-only daemon skip is reset"

--- a/tests/dind/example-storage-driver-vfs.sh
+++ b/tests/dind/example-storage-driver-vfs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/dind/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_docker
+
+container="${DIND_EXAMPLE_ID}-vfs"
+
+log "starting ${DIND_IMAGE} with DIND_STORAGE_DRIVER=vfs"
+run_dind_container "$container" -e DIND_STORAGE_DRIVER=vfs
+wait_for_inner_docker "$container"
+
+driver="$(docker exec "$container" docker info --format '{{.Driver}}' | tr -d '\r')"
+if [ "$driver" != "vfs" ]; then
+  fail "expected inner dockerd storage driver vfs, got ${driver}"
+fi
+
+log "inner dockerd is using the vfs storage driver"

--- a/tests/dind/example-sudoers-extension.sh
+++ b/tests/dind/example-sudoers-extension.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/dind/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_docker
+
+tmp_dir="$(mktemp -d)"
+derived_image="${DIND_EXAMPLE_ID}-sudoers"
+
+register_temp_dir "$tmp_dir"
+register_image "$derived_image"
+
+cat > "$tmp_dir/Dockerfile" <<'DOCKERFILE'
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+RUN printf '%s\n' 'box ALL=(root) NOPASSWD: /usr/bin/id' \
+      | install -m 0440 -o root -g root /dev/stdin /etc/sudoers.d/box-dind-example-id && \
+    if command -v visudo >/dev/null 2>&1; then visudo -cf /etc/sudoers.d/box-dind-example-id >/dev/null; fi
+
+USER box
+ENV HOME=/home/box
+DOCKERFILE
+
+log "building a derived image with a separate sudoers extension"
+docker build --build-arg BASE_IMAGE="$DIND_IMAGE" -t "$derived_image" "$tmp_dir" >/dev/null
+
+root_uid="$(docker run --rm --entrypoint=/bin/bash "$derived_image" -lc 'sudo -n /usr/bin/id -u' | tr -d '\r')"
+if [ "$root_uid" != "0" ]; then
+  fail "expected sudoers extension to allow /usr/bin/id as root, got uid ${root_uid}"
+fi
+
+log "separate sudoers extension allows only the added binary"

--- a/tests/dind/lib.sh
+++ b/tests/dind/lib.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+dind_example_basename() {
+  basename "${BASH_SOURCE[1]}" .sh | tr -c '[:alnum:].-' '-'
+}
+
+: "${DIND_IMAGE:=konard/box-dind:latest}"
+: "${DIND_RUNTIME_FLAG:=--privileged}"
+: "${DIND_WAIT_SECONDS:=60}"
+: "${DIND_KEEP_CONTAINERS:=0}"
+: "${DIND_EXAMPLE_ID:=$(dind_example_basename)-$$}"
+
+declare -a DIND_EXAMPLE_CONTAINERS=()
+declare -a DIND_EXAMPLE_IMAGES=()
+declare -a DIND_EXAMPLE_TEMP_DIRS=()
+
+log() {
+  printf '[%s] %s\n' "$(basename "$0")" "$*"
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$(basename "$0")" "$*" >&2
+  exit 1
+}
+
+register_container() {
+  DIND_EXAMPLE_CONTAINERS+=("$1")
+}
+
+register_image() {
+  DIND_EXAMPLE_IMAGES+=("$1")
+}
+
+register_temp_dir() {
+  DIND_EXAMPLE_TEMP_DIRS+=("$1")
+}
+
+cleanup_dind_examples() {
+  if [ "${DIND_KEEP_CONTAINERS:-0}" = "1" ]; then
+    log "Keeping example containers and images because DIND_KEEP_CONTAINERS=1"
+    return 0
+  fi
+
+  for container in "${DIND_EXAMPLE_CONTAINERS[@]}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+
+  for image in "${DIND_EXAMPLE_IMAGES[@]}"; do
+    docker rmi -f "$image" >/dev/null 2>&1 || true
+  done
+
+  for dir in "${DIND_EXAMPLE_TEMP_DIRS[@]}"; do
+    rm -rf "$dir"
+  done
+}
+
+trap cleanup_dind_examples EXIT
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    fail "docker CLI is required"
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    fail "docker daemon is required"
+  fi
+}
+
+run_container_from_image() {
+  local name="$1"
+  local image="$2"
+  shift 2
+
+  local -a runtime_args=()
+  if [ -n "${DIND_RUNTIME_FLAG:-}" ]; then
+    read -r -a runtime_args <<< "$DIND_RUNTIME_FLAG"
+  fi
+
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  register_container "$name"
+  docker run -d "${runtime_args[@]}" --name "$name" "$@" "$image" sleep infinity >/dev/null
+}
+
+run_dind_container() {
+  local name="$1"
+  shift
+  run_container_from_image "$name" "$DIND_IMAGE" "$@"
+}
+
+wait_for_inner_docker() {
+  local container="$1"
+  local limit="${2:-$DIND_WAIT_SECONDS}"
+  local i=0
+
+  while [ "$i" -lt "$limit" ]; do
+    if docker exec "$container" docker info >/dev/null 2>&1; then
+      log "inner dockerd is ready in ${container} after ${i}s"
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+
+  docker logs "$container" >&2 || true
+  docker exec "$container" /bin/bash -lc 'tail -n 80 "${DIND_LOG_FILE:-/var/log/dockerd.log}"' >&2 || true
+  fail "inner dockerd did not become ready in ${container} within ${limit}s"
+}
+
+assert_box_exec_user() {
+  local container="$1"
+  local actual_user
+  local actual_home
+
+  actual_user="$(docker exec "$container" whoami | tr -d '\r')"
+  if [ "$actual_user" != "box" ]; then
+    fail "expected docker exec user to be box, got ${actual_user}"
+  fi
+
+  actual_home="$(docker exec "$container" /bin/bash -lc 'printf %s "$HOME"' | tr -d '\r')"
+  if [ "$actual_home" != "/home/box" ]; then
+    fail "expected docker exec HOME to be /home/box, got ${actual_home}"
+  fi
+}

--- a/ubuntu/24.04/dind/Dockerfile
+++ b/ubuntu/24.04/dind/Dockerfile
@@ -52,7 +52,9 @@ WORKDIR /home/box
 
 SHELL ["/bin/bash", "-c"]
 
-# IMPORTANT: dind-entrypoint.sh starts dockerd as root and then drops to box
-# via runuser/su. Do not switch back to USER box here.
+# Keep docker exec behavior consistent with the non-dind box images. The
+# dind entrypoint uses scoped passwordless sudo only for dockerd setup.
+USER box
+ENV HOME=/home/box
 ENTRYPOINT ["/usr/local/bin/dind-entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/ubuntu/24.04/dind/Dockerfile
+++ b/ubuntu/24.04/dind/Dockerfile
@@ -41,8 +41,10 @@ RUN chmod +x /tmp/install.sh /tmp/common.sh /tmp/dind-entrypoint.sh && \
     bash /tmp/install.sh && \
     rm -f /tmp/install.sh /tmp/common.sh /tmp/dind-entrypoint.sh
 
-# Sanity: docker, dockerd, buildx, compose must all be present.
-RUN docker --version && \
+# Sanity: docker, dockerd, buildx, compose must all be present at the paths
+# the entrypoint and sudoers contract depend on.
+RUN test -x /usr/bin/dockerd && \
+    docker --version && \
     dockerd --version && \
     docker buildx version && \
     docker compose version

--- a/ubuntu/24.04/dind/dind-entrypoint.sh
+++ b/ubuntu/24.04/dind/dind-entrypoint.sh
@@ -2,11 +2,11 @@
 # Entrypoint for dind-box images.
 #
 # Responsibilities:
-#   1. Start the inner Docker daemon (dockerd) in the background as root,
-#      with a storage driver suitable for "Docker inside a container".
+#   1. Start the inner Docker daemon (dockerd) in the background with root
+#      privileges, using scoped passwordless sudo when the image runs as box.
 #   2. Wait for dockerd to be ready on /var/run/docker.sock.
-#   3. Hand off to the standard /usr/local/bin/entrypoint.sh as the box user
-#      so all language environments load exactly like in the regular box.
+#   3. Hand off to the standard /usr/local/bin/entrypoint.sh so all language
+#      environments load exactly like in the regular box.
 #
 # This is the recommended pattern from docker:dind and cruizba/ubuntu-dind.
 # See docs/case-studies/issue-80/CASE-STUDY.md for the full design rationale.
@@ -33,13 +33,48 @@ DIND_SKIP_DAEMON="${DIND_SKIP_DAEMON:-0}"
 log()  { echo "[dind-entrypoint] $*"; }
 warn() { echo "[dind-entrypoint] WARN: $*" >&2; }
 
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo -n "$@"
+  else
+    return 1
+  fi
+}
+
+prepare_log_file() {
+  log_dir="$(dirname "$DIND_LOG_FILE")"
+  if [ -n "$log_dir" ] && [ "$log_dir" != "." ]; then
+    as_root /usr/bin/mkdir -p "$log_dir" 2>/dev/null || true
+  fi
+
+  if ! (: >>"$DIND_LOG_FILE") 2>/dev/null; then
+    warn "Cannot write dockerd log file at ${DIND_LOG_FILE}; falling back to /tmp/dockerd.log"
+    DIND_LOG_FILE="/tmp/dockerd.log"
+    : >>"$DIND_LOG_FILE"
+  fi
+}
+
+fix_socket_permissions() {
+  if [ -S /var/run/docker.sock ]; then
+    as_root /usr/bin/chgrp docker /var/run/docker.sock 2>/dev/null || true
+    as_root /usr/bin/chmod 660 /var/run/docker.sock 2>/dev/null || true
+  fi
+}
+
 start_dockerd() {
   if pgrep -x dockerd >/dev/null 2>&1; then
     log "dockerd already running (pid $(pgrep -x dockerd | head -n1))"
+    fix_socket_permissions
     return 0
   fi
 
-  mkdir -p "$DIND_DATA_ROOT" /var/log /var/run
+  if ! as_root /usr/bin/mkdir -p "$DIND_DATA_ROOT" /var/log /var/run; then
+    warn "Cannot create dockerd runtime directories; sudo may not be configured for box"
+    return 1
+  fi
+  prepare_log_file
 
   # Pick a storage driver. overlay2 is the modern default; if it fails (the host
   # can't mount overlay-on-overlay without fuse-overlayfs), fall back to vfs.
@@ -55,15 +90,24 @@ start_dockerd() {
   log "Starting dockerd (storage-driver=${DIND_STORAGE_DRIVER}, data-root=${DIND_DATA_ROOT})"
 
   # iptables module may not be available in the outer container; let dockerd handle it.
-  nohup dockerd \
-    --host=unix:///var/run/docker.sock \
-    --data-root="$DIND_DATA_ROOT" \
-    --storage-driver="$DIND_STORAGE_DRIVER" \
-    >>"$DIND_LOG_FILE" 2>&1 &
+  if [ "$(id -u)" -eq 0 ]; then
+    nohup /usr/bin/dockerd \
+      --host=unix:///var/run/docker.sock \
+      --data-root="$DIND_DATA_ROOT" \
+      --storage-driver="$DIND_STORAGE_DRIVER" \
+      >>"$DIND_LOG_FILE" 2>&1 &
+  else
+    nohup sudo -n /usr/bin/dockerd \
+      --host=unix:///var/run/docker.sock \
+      --data-root="$DIND_DATA_ROOT" \
+      --storage-driver="$DIND_STORAGE_DRIVER" \
+      >>"$DIND_LOG_FILE" 2>&1 &
+  fi
 
   # Wait until dockerd answers on /var/run/docker.sock.
   i=0
   while [ "$i" -lt "$DIND_WAIT_SECONDS" ]; do
+    fix_socket_permissions
     if docker info >/dev/null 2>&1; then
       log "dockerd is ready after ${i}s"
       return 0
@@ -80,22 +124,18 @@ start_dockerd() {
 }
 
 if [ "$DIND_SKIP_DAEMON" != "1" ]; then
-  if [ "$(id -u)" -eq 0 ]; then
-    start_dockerd || true
-  else
-    warn "Not running as root; cannot start dockerd. Use --user root or set DIND_SKIP_DAEMON=1 to silence."
+  if ! start_dockerd; then
+    warn "dockerd startup failed. Use --user root, check /etc/sudoers.d/box-dind, or set DIND_SKIP_DAEMON=1 to silence."
   fi
 fi
 
 # Ensure the docker socket is group-readable for the box user.
-if [ -S /var/run/docker.sock ]; then
-  chgrp docker /var/run/docker.sock 2>/dev/null || true
-  chmod 660 /var/run/docker.sock 2>/dev/null || true
-fi
+fix_socket_permissions
 
-# Hand off to the box user via the existing entrypoint, which sources all the
-# language environment managers. If no upstream entrypoint exists (e.g. base
-# image is the bare js box), exec the command directly.
+# Hand off via the existing entrypoint, which sources all the language
+# environment managers. If no upstream entrypoint exists (e.g. base image is
+# the bare js box), exec the command directly. Keep the root fallback for
+# explicit --user root runs.
 if [ "$#" -eq 0 ]; then
   set -- /bin/bash
 fi

--- a/ubuntu/24.04/dind/dind-entrypoint.sh
+++ b/ubuntu/24.04/dind/dind-entrypoint.sh
@@ -16,7 +16,7 @@
 #   - Sysbox :  docker run --runtime=sysbox-runc konard/<base>-dind   (no --privileged)
 #
 # Environment overrides:
-#   DIND_STORAGE_DRIVER  Override storage driver (default: auto-detected: overlay2, fallback to vfs)
+#   DIND_STORAGE_DRIVER  Override storage driver (default: auto-detected: overlay2, fuse-overlayfs, vfs)
 #   DIND_DATA_ROOT       Override --data-root for dockerd (default: /var/lib/docker)
 #   DIND_LOG_FILE        Where to write dockerd logs (default: /var/log/dockerd.log)
 #   DIND_WAIT_SECONDS    How long to wait for dockerd to come up (default: 30)
@@ -66,6 +66,68 @@ fix_socket_permissions() {
   fi
 }
 
+storage_driver_candidates() {
+  if [ -n "$DIND_STORAGE_DRIVER" ]; then
+    printf '%s\n' "$DIND_STORAGE_DRIVER"
+    return 0
+  fi
+
+  if grep -q overlay /proc/filesystems 2>/dev/null; then
+    printf '%s\n' overlay2
+  fi
+
+  if command -v fuse-overlayfs >/dev/null 2>&1; then
+    printf '%s\n' fuse-overlayfs
+  fi
+
+  printf '%s\n' vfs
+}
+
+launch_dockerd() {
+  storage_driver="$1"
+
+  if [ "$(id -u)" -eq 0 ]; then
+    nohup /usr/bin/dockerd \
+      --host=unix:///var/run/docker.sock \
+      --data-root="$DIND_DATA_ROOT" \
+      --storage-driver="$storage_driver" \
+      >>"$DIND_LOG_FILE" 2>&1 &
+  else
+    nohup sudo -n /usr/bin/dockerd \
+      --host=unix:///var/run/docker.sock \
+      --data-root="$DIND_DATA_ROOT" \
+      --storage-driver="$storage_driver" \
+      >>"$DIND_LOG_FILE" 2>&1 &
+  fi
+
+  DIND_DOCKERD_PID="$!"
+}
+
+wait_for_dockerd_ready() {
+  dockerd_pid="$1"
+  storage_driver="$2"
+  i=0
+
+  while [ "$i" -lt "$DIND_WAIT_SECONDS" ]; do
+    fix_socket_permissions
+    if docker info >/dev/null 2>&1; then
+      log "dockerd is ready after ${i}s"
+      return 0
+    fi
+
+    if ! kill -0 "$dockerd_pid" 2>/dev/null; then
+      wait "$dockerd_pid" 2>/dev/null || true
+      warn "dockerd exited before becoming ready with storage-driver=${storage_driver}"
+      return 1
+    fi
+
+    i=$((i + 1))
+    sleep 1
+  done
+
+  return 2
+}
+
 start_dockerd() {
   if pgrep -x dockerd >/dev/null 2>&1; then
     log "dockerd already running (pid $(pgrep -x dockerd | head -n1))"
@@ -79,47 +141,42 @@ start_dockerd() {
   fi
   prepare_log_file
 
-  # Pick a storage driver. overlay2 is the modern default; if it fails (the host
-  # can't mount overlay-on-overlay without fuse-overlayfs), fall back to vfs.
-  if [ -z "$DIND_STORAGE_DRIVER" ]; then
-    if grep -q overlay /proc/filesystems 2>/dev/null; then
-      DIND_STORAGE_DRIVER="overlay2"
-    elif command -v fuse-overlayfs >/dev/null 2>&1; then
-      DIND_STORAGE_DRIVER="fuse-overlayfs"
+  # iptables modules and overlay mounts depend on the outer runtime. Auto mode
+  # retries conservative drivers only when dockerd exits before it is ready.
+  explicit_storage_driver=0
+  if [ -n "$DIND_STORAGE_DRIVER" ]; then
+    explicit_storage_driver=1
+  fi
+
+  for storage_driver in $(storage_driver_candidates); do
+    DIND_STORAGE_DRIVER="$storage_driver"
+    log "Starting dockerd (storage-driver=${DIND_STORAGE_DRIVER}, data-root=${DIND_DATA_ROOT})"
+    launch_dockerd "$DIND_STORAGE_DRIVER"
+
+    if wait_for_dockerd_ready "$DIND_DOCKERD_PID" "$DIND_STORAGE_DRIVER"; then
+      return 0
     else
-      DIND_STORAGE_DRIVER="vfs"
+      result="$?"
     fi
-  fi
-  log "Starting dockerd (storage-driver=${DIND_STORAGE_DRIVER}, data-root=${DIND_DATA_ROOT})"
 
-  # iptables module may not be available in the outer container; let dockerd handle it.
-  if [ "$(id -u)" -eq 0 ]; then
-    nohup /usr/bin/dockerd \
-      --host=unix:///var/run/docker.sock \
-      --data-root="$DIND_DATA_ROOT" \
-      --storage-driver="$DIND_STORAGE_DRIVER" \
-      >>"$DIND_LOG_FILE" 2>&1 &
-  else
-    nohup sudo -n /usr/bin/dockerd \
-      --host=unix:///var/run/docker.sock \
-      --data-root="$DIND_DATA_ROOT" \
-      --storage-driver="$DIND_STORAGE_DRIVER" \
-      >>"$DIND_LOG_FILE" 2>&1 &
-  fi
-
-  # Wait until dockerd answers on /var/run/docker.sock.
-  i=0
-  while [ "$i" -lt "$DIND_WAIT_SECONDS" ]; do
-    fix_socket_permissions
-    if docker info >/dev/null 2>&1; then
-      log "dockerd is ready after ${i}s"
+    if [ "$result" -eq 2 ]; then
+      warn "dockerd did not become ready within ${DIND_WAIT_SECONDS}s"
+      warn "Last 40 lines of ${DIND_LOG_FILE}:"
+      tail -n 40 "$DIND_LOG_FILE" >&2 || true
+      warn "Continuing anyway; the user shell will still start, but 'docker' may fail"
       return 0
     fi
-    i=$((i + 1))
-    sleep 1
+
+    if [ "$explicit_storage_driver" -eq 1 ]; then
+      break
+    fi
+
+    warn "Last 20 lines of ${DIND_LOG_FILE}:"
+    tail -n 20 "$DIND_LOG_FILE" >&2 || true
+    warn "Retrying dockerd with next storage driver"
   done
 
-  warn "dockerd did not become ready within ${DIND_WAIT_SECONDS}s"
+  warn "dockerd did not become ready with any configured storage driver"
   warn "Last 40 lines of ${DIND_LOG_FILE}:"
   tail -n 40 "$DIND_LOG_FILE" >&2 || true
   warn "Continuing anyway; the user shell will still start, but 'docker' may fail"

--- a/ubuntu/24.04/dind/dind-entrypoint.sh
+++ b/ubuntu/24.04/dind/dind-entrypoint.sh
@@ -52,7 +52,10 @@ prepare_log_file() {
   if ! (: >>"$DIND_LOG_FILE") 2>/dev/null; then
     warn "Cannot write dockerd log file at ${DIND_LOG_FILE}; falling back to /tmp/dockerd.log"
     DIND_LOG_FILE="/tmp/dockerd.log"
-    : >>"$DIND_LOG_FILE"
+    if ! (: >>"$DIND_LOG_FILE") 2>/dev/null; then
+      warn "Cannot write fallback dockerd log file at ${DIND_LOG_FILE}; using /dev/null"
+      DIND_LOG_FILE="/dev/null"
+    fi
   fi
 }
 

--- a/ubuntu/24.04/dind/install.sh
+++ b/ubuntu/24.04/dind/install.sh
@@ -85,6 +85,21 @@ else
   log_warning "box user not present yet; skipping group membership"
 fi
 
+# --- Allow the box-owned entrypoint to perform only the root setup dind needs ---
+if id box &>/dev/null; then
+  log_step "Configuring scoped sudo for dind entrypoint"
+  printf '%s\n' \
+    'box ALL=(root) NOPASSWD: /usr/bin/dockerd, /usr/bin/chgrp, /usr/bin/chmod, /usr/bin/mkdir' \
+    | maybe_sudo install -m 0440 -o root -g root /dev/stdin /etc/sudoers.d/box-dind
+  if command_exists visudo; then
+    maybe_sudo visudo -cf /etc/sudoers.d/box-dind >/dev/null
+  fi
+  maybe_sudo install -m 0644 -o box -g box /dev/null /var/log/dockerd.log
+  log_success "Configured dind sudoers entry and writable dockerd log"
+else
+  log_warning "box user not present; skipping dind sudoers entry"
+fi
+
 # --- Install dind entrypoint ---
 log_step "Installing dind entrypoint"
 maybe_sudo install -m 0755 "$SCRIPT_DIR/dind-entrypoint.sh" /usr/local/bin/dind-entrypoint.sh


### PR DESCRIPTION
Fixes #88

## Summary
- Set dind images back to `USER box` so `docker exec` and entrypoint-bypassed shells match the regular box images.
- Add a scoped `box` sudoers entry for the dind entrypoint commands that still need root: starting `dockerd` and fixing socket permissions.
- Update `dind-entrypoint.sh` to start dockerd through that scoped sudo path when running as `box`, while preserving the existing `--user root` fallback.
- Retry auto-selected dockerd storage drivers when the daemon exits before readiness, so nested runtimes that reject `overlay2` can fall back to `fuse-overlayfs` or `vfs` without requiring manual env overrides.
- Extend the `pr-test-dind` matrix to assert `Config.User=box`, `whoami=box`, `HOME=/home/box`, and passwordless `dockerd --version` sudo access.
- Add `docs/dind/USAGE.md` plus executable examples under `tests/dind/` for the basic runtime flow, commit-cycle `DIND_SKIP_DAEMON` handling, sudoers extension, and forced `vfs` storage driver.
- Run those documented examples in PR CI against the locally built `box-dind-js` image, and add a build-time guard that `/usr/bin/dockerd` exists at the sudoers-pinned path.

## Reproduction
Before this change, `ubuntu/24.04/dind/Dockerfile` left the final image as `USER root`, so `docker exec <dind-container> whoami` returned `root` even though the main container command was later dropped to `box` by the entrypoint.

The CI regression test reproduces the configured-user path by checking the built image's `Config.User` plus entrypoint-bypassed `whoami`/`HOME`. The documented example CI starts the dind image with `--privileged`, waits for the inner daemon, and verifies `docker exec ... docker ps` and `pgrep -x dockerd`.

During CI verification, that documented example also reproduced a nested-runtime storage-driver failure: `overlay2` was visible but not usable for the inner daemon. The entrypoint now treats an early daemon exit as an auto-selection failure and retries the next storage driver candidate.

## Testing
- `bash -n ubuntu/24.04/dind/dind-entrypoint.sh`
- `bash -n ubuntu/24.04/dind/install.sh`
- `bash -n tests/dind/lib.sh`
- `bash -n tests/dind/example-basic-docker-ps.sh`
- `bash -n tests/dind/example-commit-cycle.sh`
- `bash -n tests/dind/example-sudoers-extension.sh`
- `bash -n tests/dind/example-storage-driver-vfs.sh`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"`
- `GITHUB_BASE_REF=main GITHUB_HEAD_REF=issue-88-e338036f5bf2 ./scripts/release/validate-changeset.sh`
- GitHub Actions: https://github.com/link-foundation/box/actions/runs/26962712292

Local Docker runtime verification was not run because `docker` is not installed in this workspace. The pushed PR run exercises the new privileged documented examples in GitHub Actions.
