### PR TITLE
test(dind): assert public-mode passthrough actually copies a public host image (issue #96)

### DIFF
--- a/.changeset/issue-96-public-passthrough-positive-assertion.md
+++ b/.changeset/issue-96-public-passthrough-positive-assertion.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+dind-box: close a false-positive coverage gap in the host-image passthrough test (issue #96). `tests/dind/example-preload-images.sh` previously only asserted that `public` mode skips a locally-built fixture (no RepoDigest); it never asserted the positive path — that a genuinely public image (carrying a RepoDigest from an allowlisted registry) IS copied into the inner daemon. The throwaway host daemon is now also seeded with a real pulled `alpine:3.20`, and the `public`-mode block asserts that image lands in the nested daemon and is logged as loaded. A "public copies nothing" regression — the exact symptom downstream (`link-assistant/hive-mind#1879`) relies on not happening — now fails CI instead of shipping green.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T14:25:36.200Z for PR creation at branch issue-96-9e584ef3ffff for issue https://github.com/link-foundation/box/issues/96

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T14:25:36.200Z for PR creation at branch issue-96-9e584ef3ffff for issue https://github.com/link-foundation/box/issues/96

--- a/tests/dind/example-preload-images.sh
+++ b/tests/dind/example-preload-images.sh
@@ -145,6 +145,17 @@ log "throwaway host daemon is ready"
 docker exec -i "$host_daemon_container" \
   docker -H unix:///sockets/docker.sock load < "$tarball_dir/image.tar"
 
+# Also seed it with a genuinely public image. Pulling it from a public registry
+# is what records a RepoDigest (docker save/load does NOT preserve one), so this
+# is the "freely re-pullable" case the default public mode MUST pass through.
+# This is the positive counterpart to the fixture: without it, public mode has no
+# eligible image and a "public copies nothing" regression would ship green.
+public_image="alpine:3.20"
+log "pulling a real public image (${public_image}) into the throwaway host daemon"
+if ! $host_docker pull "$public_image" >/dev/null; then
+  fail "could not pull ${public_image} into the throwaway host daemon (network required)"
+fi
+
 # all mode: every tagged host image is copied, including this local fixture.
 log "starting consumer with DIND_HOST_PASSTHROUGH=all"
 run_dind_container "$all_container" \
@@ -174,6 +185,19 @@ if ! docker logs "$public_container" 2>&1 | grep -q "host-image passthrough (mod
   docker logs "$public_container" >&2 || true
   fail "expected the consumer to run host-image passthrough in public mode"
 fi
-log "public-mode passthrough correctly skipped the local fixture (security filter held)"
+# Positive assertion: a host image carrying a RepoDigest from an allowlisted
+# public registry MUST land in the inner daemon. This is the behavior downstream
+# relies on (link-assistant/hive-mind#1879) and the path the suite previously
+# left structurally untested, so a "public copies nothing" regression now fails.
+if ! docker exec "$public_container" docker image inspect "$public_image" >/dev/null 2>&1; then
+  docker logs "$public_container" >&2 || true
+  docker exec "$public_container" docker images >&2 || true
+  fail "public mode must pass through a host image that has a public RepoDigest (${public_image})"
+fi
+if ! docker logs "$public_container" 2>&1 | grep -q "passthrough loading host image: ${public_image}"; then
+  docker logs "$public_container" >&2 || true
+  fail "expected public mode to log loading the public host image (${public_image})"
+fi
+log "public-mode passthrough copied the public image and skipped the local fixture (security filter held)"
 
 log "preload example passed"


### PR DESCRIPTION
## Summary

Closes the false-positive / coverage gap in the host-image passthrough test added in #95 (`tests/dind/example-preload-images.sh`).

For the default `public` mode the suite previously only asserted the **negative** path — that a locally-built fixture (no RepoDigest) is **not** copied. The **positive** path the feature exists for — a genuinely public image (carrying a RepoDigest from an allowlisted registry) **is** copied into the inner daemon — was structurally untested: the throwaway host daemon was seeded with **only** the offline `docker import` fixture, so `public` mode had **no eligible image at all**. A "`public` copies nothing" regression would have shipped green, defeating the whole feature (every inner `docker run` re-pulls again) — the exact symptom #94 set out to fix, and the behavior downstream `link-assistant/hive-mind#1879` relies on.

Fixes #96.

## What changed

`tests/dind/example-preload-images.sh`:

- **Seed the throwaway host daemon with a real public image** (`alpine:3.20`). Pulling it from a public registry is what records a `RepoDigest` — `docker save`/`docker load` does **not** preserve one — so this is the "freely re-pullable" case `public` mode must pass through. The pull fails the test loudly if the network is unavailable.
- **Add the missing positive assertion** to the `public`-mode block: the public image must land in the inner daemon (`docker image inspect alpine:3.20`) **and** be logged as loaded (`passthrough loading host image: alpine:3.20`). The pre-existing negative assertion (local fixture skipped) is kept.

Also drops a stray root `.gitkeep` PR-creation artifact, and adds a `patch` changeset.

## How it was verified

- The container integration test runs in CI (`pr-test-dind`), which uses `overlay2` + the disk-cleanup step. Running it locally here is impractical because the sandbox Docker uses the `vfs` storage driver (no layer sharing), which exhausts disk while expanding the large `box-dind` image.
- The filter logic the new assertion depends on is covered by `experiments/preload-unit-test.sh` (mocked host daemon, no container needed). Case 9 already exercises precisely this path and is green:

  ```
  == Case 9: public mode copies only public-registry images ==
  [dind-entrypoint] host-image passthrough (mode=public) ...
  [dind-entrypoint] passthrough loading host image: alpine:3.20
  [dind-entrypoint] passthrough skip (filtered by mode=public): myapp:latest
    PASS: public mode saved the hub image
    PASS: public mode loaded the hub image
    PASS: public mode did NOT save the local image
  ...
  RESULT: 26 passed, 0 failed
  ```

  This confirms a `docker.io` RepoDigest image (`alpine:3.20`) passes `public` mode and emits the exact log line the new integration assertion greps for.

## Before / after (test coverage)

| `public`-mode block | before | after |
| --- | --- | --- |
| local fixture (no RepoDigest) skipped | ✅ asserted | ✅ asserted |
| public image (RepoDigest) copied into inner daemon | ❌ untested | ✅ asserted |
| public image logged as loaded | ❌ untested | ✅ asserted |
