### PR TITLE
Fix CI false positives from Docker Hub outage: add registry-mirror fallback to buildx boot (issue #100)

### DIFF
--- a/.changeset/issue-100-buildx-mirror-fallback.md
+++ b/.changeset/issue-100-buildx-mirror-fallback.md
@@ -1,0 +1,23 @@
+---
+bump: patch
+---
+
+ci: make the buildx boot survive a full Docker Hub registry outage (issue #100).
+
+Run 27314587149 failed not from a code defect but from `registry-1.docker.io`
+being unreachable for ~2.5 minutes while booting BuildKit in
+`build-languages-amd64 (java)`. The existing `setup-buildx-resilient` pre-pull
+(issue #97) only retries Docker Hub, so once the outage outlasted its retry
+budget the boot pull failed too — and that single failure cascaded into
+`box-java:<ver>-amd64: not found` and `box:<ver>-{amd64,arm64}: not found`
+across `build-dind-amd64 (java)`, `build-dind-amd64 (full)` and
+`build-dind-arm64 (full)`.
+
+`setup-buildx-resilient` now falls back to a pull-through registry mirror
+(`mirror.gcr.io`, on independent infrastructure) and re-tags the BuildKit image
+to its canonical reference so the docker-container driver boot reuses the local
+copy and never touches the failing registry. Adds an opt-in `verbose` /
+`RUNNER_DEBUG` trace and a unit test
+(`experiments/test-issue100-buildx-mirror-fallback.sh`). All 12 buildx boots in
+`release.yml` route through this one composite action, so every build job is
+hardened. Full analysis in `docs/case-studies/issue-100/CASE-STUDY.md`.

--- a/.github/actions/setup-buildx-resilient/action.yml
+++ b/.github/actions/setup-buildx-resilient/action.yml
@@ -1,45 +1,108 @@
 name: 'Set up Docker Buildx (resilient)'
 description: >
   Wrapper around docker/setup-buildx-action that first pre-pulls the pinned
-  BuildKit image with retries and exponential backoff. Booting the
-  docker-container driver otherwise pulls moby/buildkit straight from Docker
-  Hub, and a transient registry timeout there fails the whole job (and, for
-  the amd64 essentials build, cascades into "box-essentials:<ver>-amd64: not
-  found" across every dependent dind build). Seeding the image locally first
-  means the boot reuses the cached image instead of hitting the registry.
-  See the CI investigation in issue #97.
+  BuildKit image with retries and exponential backoff, and — when Docker Hub
+  itself is unreachable — falls back to a pull-through registry mirror
+  (mirror.gcr.io by default) before re-tagging the image to its canonical
+  reference. Booting the docker-container driver otherwise pulls moby/buildkit
+  straight from Docker Hub, and a transient registry timeout there fails the
+  whole job (and, for the amd64 essentials/language builds, cascades into
+  "box-<flavour>:<ver>-amd64: not found" across every dependent dind build —
+  see issue #100). Seeding the image locally first means the boot reuses the
+  cached image instead of hitting the registry, and the mirror fallback keeps
+  the seed working even during a full Docker Hub registry outage.
+  See the CI investigations in issues #97 and #100.
 inputs:
   buildkit-image:
     description: 'Pinned BuildKit image used by the docker-container driver.'
     required: false
     default: 'moby/buildkit:buildx-stable-1'
+  registry-mirror:
+    description: >
+      Pull-through Docker Hub mirror host used as a fallback when the canonical
+      registry (registry-1.docker.io) is unreachable. mirror.gcr.io is Google's
+      public pull-through cache of Docker Hub and is served from independent
+      infrastructure, so it typically stays reachable during Docker Hub
+      registry outages. Set to an empty string to disable the mirror fallback.
+    required: false
+    default: 'mirror.gcr.io'
+  verbose:
+    description: >
+      Set to "true" to enable shell tracing (set -x) in the pre-pull step for
+      debugging. Tracing is also enabled automatically when the workflow is run
+      with step debug logging (RUNNER_DEBUG=1).
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
-    - name: Pre-pull BuildKit image (retry on transient registry errors)
+    - name: Pre-pull BuildKit image (retry + registry-mirror fallback)
       shell: bash
       env:
         BUILDKIT_IMAGE: ${{ inputs.buildkit-image }}
+        REGISTRY_MIRROR: ${{ inputs.registry-mirror }}
+        VERBOSE: ${{ inputs.verbose }}
       run: |
         set -u
-        attempts=5
-        delay=5
-        for attempt in $(seq 1 "$attempts"); do
-          echo "==> Pulling ${BUILDKIT_IMAGE} (attempt ${attempt}/${attempts})..."
-          if docker pull "${BUILDKIT_IMAGE}"; then
-            echo "==> BuildKit image cached locally; boot will not need a registry pull"
+        # Verbose/debug tracing: opt-in via input, or automatic when the run is
+        # started with "Enable debug logging" (RUNNER_DEBUG=1). Kept off by
+        # default so normal logs stay readable.
+        if [ "${VERBOSE}" = "true" ] || [ "${RUNNER_DEBUG:-}" = "1" ]; then
+          echo "==> Verbose tracing enabled"
+          set -x
+        fi
+
+        # Pull a reference with bounded retries and exponential backoff.
+        # Returns 0 on the first successful pull, non-zero if all attempts fail.
+        pull_with_retries() {
+          ref="$1"
+          # Attempts/backoff are overridable via env so the unit test can run
+          # fast; the CI defaults stay at 5 attempts / 5s exponential backoff.
+          attempts="${PREPULL_ATTEMPTS:-5}"
+          delay="${PREPULL_DELAY:-5}"
+          for attempt in $(seq 1 "$attempts"); do
+            echo "==> Pulling ${ref} (attempt ${attempt}/${attempts})..."
+            if docker pull "${ref}"; then
+              return 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "==> Pull failed, waiting ${delay}s before next attempt..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          return 1
+        }
+
+        # 1) Canonical Docker Hub. The common transient-blip case recovers here.
+        if pull_with_retries "${BUILDKIT_IMAGE}"; then
+          echo "==> BuildKit image cached locally from canonical registry; boot will not need a registry pull"
+          exit 0
+        fi
+
+        # 2) Registry-mirror fallback. When Docker Hub's registry endpoint is
+        #    fully unreachable (issue #100: registry-1.docker.io timed out for
+        #    ~2.5 minutes), the canonical pull above cannot recover no matter
+        #    how many times it retries. mirror.gcr.io is a pull-through cache of
+        #    Docker Hub on independent infrastructure, so it usually still
+        #    serves the image. We pull from there and re-tag to the canonical
+        #    reference so the docker-container driver boot finds it locally and
+        #    never touches the failing registry.
+        if [ -n "${REGISTRY_MIRROR}" ]; then
+          mirror_ref="${REGISTRY_MIRROR}/${BUILDKIT_IMAGE}"
+          echo "==> Canonical pull failed; trying registry mirror ${mirror_ref}"
+          if pull_with_retries "${mirror_ref}"; then
+            docker tag "${mirror_ref}" "${BUILDKIT_IMAGE}"
+            echo "==> BuildKit image cached locally via mirror and tagged as ${BUILDKIT_IMAGE}; boot will reuse it"
             exit 0
           fi
-          if [ "$attempt" -lt "$attempts" ]; then
-            echo "==> Pull failed, waiting ${delay}s before next attempt..."
-            sleep "$delay"
-            delay=$((delay * 2))
-          fi
-        done
+          echo "==> Mirror pull from ${REGISTRY_MIRROR} also failed"
+        fi
+
         # Non-fatal: fall through to setup-buildx, which will attempt its own
         # pull during boot. This preserves the previous behaviour in the worst
         # case while making the common transient-failure case recover.
-        echo "==> WARNING: could not pre-pull ${BUILDKIT_IMAGE} after ${attempts} attempts; letting setup-buildx try its own boot pull"
+        echo "==> WARNING: could not pre-pull ${BUILDKIT_IMAGE} from canonical registry or mirror; letting setup-buildx try its own boot pull"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T07:07:21.142Z for PR creation at branch issue-100-45581ad55388 for issue https://github.com/link-foundation/box/issues/100

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T07:07:21.142Z for PR creation at branch issue-100-45581ad55388 for issue https://github.com/link-foundation/box/issues/100

--- a/docs/case-studies/issue-100/CASE-STUDY.md
+++ b/docs/case-studies/issue-100/CASE-STUDY.md
@@ -1,0 +1,199 @@
+# Case Study: Issue #100 — Transient Docker Hub outage fails the release run and cascades into "image not found" across dependent dind builds
+
+## Executive Summary
+
+Issue [#100](https://github.com/link-foundation/box/issues/100) asks us to "fix
+all false positives and errors at latest CI/CD run"
+([run 27314587149](https://github.com/link-foundation/box/actions/runs/27314587149)),
+reuse best practices from the four pipeline templates, and compile a deep case
+study with timeline, requirements, root causes and solutions.
+
+The run had **four** red jobs:
+
+| Job | Conclusion | Apparent error |
+| --- | --- | --- |
+| `build-languages-amd64 (java)` | failure | `Set up Docker Buildx` could not pull `moby/buildkit:buildx-stable-1` — `registry-1.docker.io` timed out |
+| `build-dind-amd64 (java)` | failure | `docker.io/***/box-java:2.3.0-amd64: not found` |
+| `build-dind-amd64 (full)` | failure | `docker.io/***/box:2.3.0-amd64: not found` |
+| `build-dind-arm64 (full)` | failure | `docker.io/***/box:2.3.0-arm64: not found` |
+
+All four collapse to a **single root cause**: Docker Hub's registry endpoint
+(`registry-1.docker.io`) was unreachable from the amd64 runner for ~2.5 minutes
+(00:16:40–00:19:13 UTC). That outage outlasted the existing pre-pull retry
+budget in `setup-buildx-resilient` (added for issue #97), so the `java` amd64
+language build failed at buildx boot — and that one failure cascaded through the
+release graph into three more "image not found" jobs that are not independent
+errors at all.
+
+The original `issue.md` is preserved [here](./issue.md); the raw failed-job
+logs are under [`ci-logs/`](./ci-logs/).
+
+## 1. Timeline of events (UTC)
+
+Run triggered by push of merge commit `57abb41` ("Merge pull request #99").
+
+| Time | Event |
+| --- | --- |
+| 00:06:44 | Release workflow starts. |
+| 00:14:27 | `build-languages-amd64 (java)` starts. |
+| 00:16:25 | `setup-buildx-resilient` pre-pull begins: 5 attempts to pull `moby/buildkit:buildx-stable-1`. |
+| 00:16:40 → 00:18:55 | All 5 pre-pull attempts fail: `Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded` / `context deadline exceeded`. Backoff 5→10→20→40s. |
+| 00:18:55 | Pre-pull gives up (non-fatal) and falls through to `docker/setup-buildx-action`. |
+| 00:18:58 | "Creating a new builder instance" — buildx boots the docker-container driver and tries its own registry pull. |
+| 00:19:13 | Boot pull also fails (same registry timeout). **`build-languages-amd64 (java)` → failure.** |
+| 00:26:56 | `docker-build-push`, `docker-build-push-arm64`, `languages-manifest`, `docker-manifest` are all **skipped** — their `if:` requires `needs.build-languages-amd64.result == 'success' \|\| 'skipped'`, and it was `failure`. |
+| 00:27:20 → 00:29:29 | `build-dind-arm64 (full)` runs anyway (its needs tolerate `skipped`) and fails: `box:2.3.0-arm64: not found` — the full `box` image was never built. |
+| 00:30:32 → 00:32:30 | `build-dind-amd64 (full)` fails the same way: `box:2.3.0-amd64: not found`. |
+| 00:30:47 → 00:33:00 | `build-dind-amd64 (java)` fails: `box-java:2.3.0-amd64: not found` — `java`'s own amd64 push never happened because its build failed at 00:19. |
+
+By contrast every arm64 language build and every other amd64 language build
+succeeded — the outage was a narrow, runner- and time-localized network blip on
+one amd64 runner, not a code defect.
+
+## 2. Requirements extracted from the issue
+
+1. **Fix the false positives and errors** in the latest CI/CD run.
+2. **Reuse best practices** from the JS / Rust / Python / C# pipeline templates;
+   compare *all* workflow files so the same class of error cannot recur.
+3. **If the same issue exists in a template, report it there too**, with a
+   reproducible example, workaround and suggested fix.
+4. **Compile all logs and data** for the issue into `./docs/case-studies/issue-100/`
+   and perform a deep case study: timeline, full requirement list, root cause per
+   problem, proposed solutions and plans, and a survey of existing
+   components/libraries that solve the problem.
+5. **If data is insufficient to find the root cause, add debug/verbose output**
+   so the next iteration can.
+6. **Report issues to any other affected repositories** with reproducible
+   examples, workarounds and code suggestions.
+7. **Apply the fix across the entire codebase** — fix every place that has the
+   problem, not just one.
+8. Do all of this in the single pull request
+   [#101](https://github.com/link-foundation/box/pull/101).
+
+## 3. Root-cause analysis
+
+### 3.1 The one real failure: Docker Hub registry outage during buildx boot
+
+The `docker-container` buildx driver runs BuildKit inside a container that
+dockerd must first pull (`moby/buildkit:buildx-stable-1`) from Docker Hub. Issue
+#97 already recognised that a transient registry blip there fails the whole job,
+and added [`setup-buildx-resilient`](../../../.github/actions/setup-buildx-resilient/action.yml):
+it pre-pulls the BuildKit image with 5 retries so the boot reuses a locally
+cached copy.
+
+That hardening assumes the registry is *intermittently* reachable. In this run
+`registry-1.docker.io` was **continuously** unreachable for ~2.5 minutes — longer
+than the pre-pull's ~2.5-minute budget — so:
+
+- all 5 pre-pull attempts failed, then
+- the boot's own pull (the original failure mode #97 tried to avoid) failed too,
+- because **both** the pre-pull and the boot pull only ever talk to Docker Hub.
+
+Retrying the *same* unreachable host more or longer is the wrong lever; the fix
+needs a **second, independent source** for the BuildKit image.
+
+### 3.2 The three cascade failures (not independent errors)
+
+`docker-build-push` (full amd64 `box`) gates on
+`build-languages-amd64.result == 'success' || 'skipped'`. With that job
+`failure`, it skipped; `docker-build-push-arm64` gates on `docker-build-push`
+success, so it skipped too; `languages-manifest` and `docker-manifest` likewise
+skipped. The full `box:2.3.0-{amd64,arm64}` images were therefore never built.
+
+The `build-dind-*` jobs, however, gate on their manifest needs being
+`success` **or `skipped`** (so dind can still run when only some flavours
+changed). With the manifests skipped, the dind `full` jobs ran and tried to
+build `FROM docker.io/***/box:2.3.0-<arch>`, which does not exist → "not found".
+Likewise `build-dind-amd64 (java)` built `FROM box-java:2.3.0-amd64`, which the
+failed `java` build never pushed.
+
+So three of the four red jobs are **downstream symptoms** of 3.1. They are the
+"false positives" the issue refers to: the dind builds were never broken; they
+were starved of a base image by an upstream network blip. Eliminating the root
+cause (3.1) removes all four reds together. (A possible future refinement —
+skipping dind `full`/`java` when their base manifest was skipped rather than
+letting them fail on a missing base — is noted in §5 as defense-in-depth, but is
+deliberately *not* the primary fix because a skipped base on a real release is
+itself a signal that should not be silently green.)
+
+## 4. The fix (this PR)
+
+`setup-buildx-resilient` now seeds the BuildKit image from a **pull-through
+registry mirror on independent infrastructure** when Docker Hub is unreachable:
+
+1. Pull `moby/buildkit:buildx-stable-1` from Docker Hub with the existing 5×
+   exponential-backoff retries (handles the common transient blip).
+2. **New:** if that exhausts, pull `mirror.gcr.io/moby/buildkit:buildx-stable-1`
+   (Google's public pull-through cache of Docker Hub, served from Google infra
+   that is essentially never down at the same instant as Docker Hub), then
+   `docker tag` it back to the canonical `moby/buildkit:buildx-stable-1`. The
+   docker-container driver boot then finds the image locally and **never touches
+   the failing registry**.
+3. If even the mirror fails, fall through to the previous behaviour (let buildx
+   try its own boot pull) — strictly no worse than before.
+
+Supporting changes:
+
+- **Verbose/debug mode** (requirement 5): a `verbose` input plus automatic
+  tracing under `RUNNER_DEBUG=1`, so a future outage prints `set -x` detail of
+  exactly which source served (or failed) the pull.
+- **Tunable retry budget** via `PREPULL_ATTEMPTS` / `PREPULL_DELAY` env (CI
+  defaults unchanged at 5 / 5s), used by the unit test to run fast.
+- **Codebase-wide coverage** (requirement 7): every `Set up Docker Buildx` in
+  `release.yml` (12 occurrences) already routes through this one composite
+  action, so the single edit hardens **all** buildx boots — JS, essentials,
+  every language, the full `box` image, both arch push jobs, and every dind
+  variant. No other workflow boots buildx.
+- **Unit test**
+  [`experiments/test-issue100-buildx-mirror-fallback.sh`](../../../experiments/test-issue100-buildx-mirror-fallback.sh)
+  extracts the real pre-pull script out of `action.yml` and drives it with a
+  mock `docker` for three scenarios: canonical-healthy (no mirror touched),
+  Docker-Hub-down/mirror-healthy (recovers + re-tags — the issue #100 scenario),
+  and both-down (non-fatal fall-through), plus static assertions on the action.
+
+### 4.1 Existing components / prior art considered
+
+| Option | Verdict |
+| --- | --- |
+| `mirror.gcr.io` pull-through cache | **Chosen.** Zero-config, public, independent infra, well-documented Docker Hub mirror; smallest surgical change. |
+| Configure dockerd `registry-mirrors` in `/etc/docker/daemon.json` + restart | Covers boot pulls natively but adds a daemon restart to every job and is heavier than a targeted re-tag; rejected for now. |
+| `nick-fields/retry` around `setup-buildx-action` | Only retries the same unreachable host; does not add an independent source. Insufficient alone. |
+| Mirror `moby/buildkit` into GHCR ourselves | Works but adds a maintenance/publishing burden and another moving part vs. an existing public mirror. |
+| Switch buildx to the default `docker` driver | Avoids the BuildKit container pull but loses multi-platform / cache-export features the release relies on. Not viable. |
+
+## 5. Defense-in-depth / future work (not required to close this issue)
+
+- Optionally gate `build-dind-*` (full/java) on the *actual* base manifest having
+  been built (e.g. condition on `docker-manifest.result == 'success'` for `full`)
+  so a skipped base yields a skip, not a confusing "not found" failure. Kept out
+  of this PR to avoid masking genuinely missing-base releases.
+- Consider applying the same mirror fallback default to the templates (see §6).
+
+## 6. Template comparison and upstream reports (requirements 2, 3, 6)
+
+The four templates were compared for the same buildx-boot exposure:
+
+- **rust-ai-driven-development-pipeline-template** — uses
+  `docker/setup-buildx-action@v4` **with no pinned-image pre-pull and no mirror
+  fallback** (`release.yml`). Its boot pulls `moby/buildkit` straight from Docker
+  Hub, so it is vulnerable to exactly this outage. → reported upstream with the
+  `setup-buildx-resilient` pattern as the suggested fix.
+- **js-ai-driven-development-pipeline-template** — publishes via a
+  `publish-dockerhub` composite action; reviewed for the same gap.
+- **python-** / **csharp-…-template** — `release.yml` reviewed; buildx-boot
+  exposure assessed.
+
+Upstream issue links are recorded in [`template-reports.md`](./template-reports.md).
+
+## 7. Verification
+
+```
+$ bash experiments/test-issue100-buildx-mirror-fallback.sh
+...
+PASS=15 FAIL=0
+All issue #100 buildx mirror-fallback checks passed.
+```
+
+`release.yml` and the composite `action.yml` both pass `YAML.load_file`. The
+real-world verification is the next release run booting buildx through the mirror
+fallback when Docker Hub blips.

--- a/docs/case-studies/issue-100/ci-logs/README.md
+++ b/docs/case-studies/issue-100/ci-logs/README.md
@@ -1,0 +1,71 @@
+# CI evidence — run 27314587149 (issue #100)
+
+The full raw job logs are `*.log` in this directory but are **git-ignored**
+(repo-wide `*.log` rule) because they are large and ANSI-laden. To re-download
+them:
+
+```bash
+for id in 80693193608 80694639183 80694639277 80694639315; do
+  gh run view --repo link-foundation/box --log --job "$id" \
+    > docs/case-studies/issue-100/ci-logs/job-$id.log
+done
+```
+
+Run: <https://github.com/link-foundation/box/actions/runs/27314587149>
+(push of merge commit `57abb41`, 2026-06-11 00:06:44 UTC).
+
+## Decisive excerpts
+
+### 1. Root cause — `build-languages-amd64 (java)` ([job 80693193608](https://github.com/link-foundation/box/actions/runs/27314587149/job/80693193608))
+
+`setup-buildx-resilient` pre-pull exhausts all 5 retries against Docker Hub:
+
+```
+00:16:25 ==> Pulling moby/buildkit:buildx-stable-1 (attempt 1/5)...
+00:16:40 Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+00:16:40 ==> Pull failed, waiting 5s before next attempt...
+... attempts 2/5 .. 5/5, backoff 10s/20s/40s, same timeout ...
+00:18:55 ==> WARNING: could not pre-pull moby/buildkit:buildx-stable-1 after 5 attempts; letting setup-buildx try its own boot pull
+```
+
+Then the buildx boot's own pull fails the same way and fails the job:
+
+```
+00:18:58 ##[group]Creating a new builder instance
+00:19:13 #1 ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+00:19:13 ##[error]ERROR: ... registry-1.docker.io ... Client.Timeout exceeded ...
+```
+
+### 2. Cascade — `build-dind-amd64 (java)` ([job 80694639277](https://github.com/link-foundation/box/actions/runs/27314587149/job/80694639277))
+
+The java amd64 base image was never pushed, so the dependent dind build cannot resolve it:
+
+```
+#3 ERROR: docker.io/***/box-java:2.3.0-amd64: not found
+ERROR: failed to build: failed to solve: ***/box-java:2.3.0-amd64: failed to resolve source metadata ... not found
+##[error]Process completed with exit code 1.
+```
+
+### 3. Cascade — `build-dind-amd64 (full)` ([job 80694639315](https://github.com/link-foundation/box/actions/runs/27314587149/job/80694639315))
+
+`docker-build-push` was skipped (it requires `build-languages-amd64` success), so the full `box` amd64 image was never built:
+
+```
+#3 ERROR: docker.io/***/box:2.3.0-amd64: not found
+ERROR: failed to build: failed to solve: ***/box:2.3.0-amd64: ... not found
+```
+
+### 4. Cascade — `build-dind-arm64 (full)` ([job 80694639183](https://github.com/link-foundation/box/actions/runs/27314587149/job/80694639183))
+
+Same skip chain (`docker-build-push-arm64` needs `docker-build-push`):
+
+```
+#2 ERROR: docker.io/***/box:2.3.0-arm64: not found
+ERROR: failed to build: failed to solve: ***/box:2.3.0-arm64: ... not found
+```
+
+## Why arm64 language builds were green
+
+Every arm64 language build and every other amd64 language build succeeded in the
+same run — the outage was a narrow network blip localized to one amd64 runner
+during the 00:16–00:19 window, not a code defect. See `../CASE-STUDY.md` §1.

--- a/docs/case-studies/issue-100/issue.md
+++ b/docs/case-studies/issue-100/issue.md
@@ -1,0 +1,21 @@
+# Issue #100: Fix all false positives and errors at latest CI/CD run
+
+_Opened by @konard on 2026-06-11T07:04:04Z_
+
+https://github.com/link-foundation/box/actions/runs/27314587149
+
+Use all the best practices from CI/CD templates (check full file tree to compare for all GitHub workflow and CI/CD scripts file), if the same issue is found in template report issue also in templates:
+- https://github.com/link-foundation/js-ai-driven-development-pipeline-template
+- https://github.com/link-foundation/rust-ai-driven-development-pipeline-template
+- https://github.com/link-foundation/python-ai-driven-development-pipeline-template
+- https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template
+
+We should compare all files, so we don't have more CI/CD errors in the future and reuse all the best practices from these templates.
+
+We need to download all logs and data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), in which we will reconstruct timeline/sequence of events, list of each and all requirements from the issue, find root causes of the each problem, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).
+
+If there is not enough data to find actual root cause, add debug output and verbose mode if not present, that will allow us to find root cause on next iteration.
+
+If issue related to any other repository/project, where we can report issues on GitHub, please do so. Each issue must contain reproducible examples, workarounds and suggestions for fix the issue in code. Also double check to fully apply requirements to entire codebase, so if we have issue in multiple places, it should be fixed in all them.
+
+Please plan and execute everything in this single pull request, you have unlimited time and context, as context auto-compacts and you can continue indefinitely, until it is each and every requirement fully addressed, and everything is totally done.

--- a/docs/case-studies/issue-100/template-reports.md
+++ b/docs/case-studies/issue-100/template-reports.md
@@ -1,0 +1,33 @@
+# Template comparison & upstream reports (issue #100, requirements 2/3/6)
+
+The issue asks us to compare the four pipeline templates for the same class of
+CI error and, where a template shares the defect, report it upstream with a
+reproducible example, workaround and suggested fix.
+
+## Method
+
+For each template we inspected every file under `.github/workflows/` and
+`.github/actions/` for buildx usage (`docker/setup-buildx-action`,
+`docker/build-push-action`, `moby/buildkit`, registry-mirror configuration).
+The relevant exposure is the **buildx boot pull**: the default `docker-container`
+driver makes dockerd pull `moby/buildkit:buildx-stable-1` from Docker Hub, so a
+transient `registry-1.docker.io` outage fails the job (the issue #100 root
+cause).
+
+## Findings
+
+| Template | Boots buildx? | Pre-pull / mirror fallback? | Exposed? | Action |
+| --- | --- | --- | --- | --- |
+| [rust](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template) | Yes — `docker/setup-buildx-action@v4` in `release.yml` (two jobs) | No | **Yes** | Reported: [issue #69](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/69) |
+| [js](https://github.com/link-foundation/js-ai-driven-development-pipeline-template) | Yes — `docker/setup-buildx-action@v4` + `build-push-action@v7` in `.github/actions/publish-dockerhub` | No | **Yes** | Reported: [issue #75](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/75) |
+| [python](https://github.com/link-foundation/python-ai-driven-development-pipeline-template) | No buildx / docker build in any workflow | n/a | No | None needed |
+| [csharp](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template) | No buildx / docker build in any workflow | n/a | No | None needed |
+
+## Suggested upstream fix (shared)
+
+Both reports propose porting the `box` repo's reusable composite action
+[`setup-buildx-resilient`](../../../.github/actions/setup-buildx-resilient/action.yml):
+pre-pull the pinned BuildKit image with retries, fall back to
+`mirror.gcr.io/moby/buildkit:buildx-stable-1` when Docker Hub is unreachable,
+re-tag to the canonical reference, then boot buildx with
+`driver-opts: image=moby/buildkit:buildx-stable-1` so it reuses the cached copy.

--- a/experiments/test-issue100-buildx-mirror-fallback.sh
+++ b/experiments/test-issue100-buildx-mirror-fallback.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Unit test for the issue #100 buildx-boot resilience hardening in
+# .github/actions/setup-buildx-resilient/action.yml.
+#
+# Root cause (issue #100): registry-1.docker.io was unreachable for ~2.5 min
+# during a release run, so the docker-container driver could not pull
+# moby/buildkit:buildx-stable-1. The pre-pull retries exhausted and the buildx
+# boot's own pull failed too, taking down build-languages-amd64 (java) and
+# cascading "box*:<ver>-amd64: not found" into every dependent dind build.
+#
+# The fix adds a pull-through registry-mirror fallback (mirror.gcr.io) plus a
+# re-tag to the canonical reference so a full Docker Hub outage no longer fails
+# the boot. This test extracts the real pre-pull script out of action.yml and
+# drives it with a mock `docker` that can independently fail the canonical
+# registry and/or the mirror, asserting the recovery behaviour for every case.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION="$SCRIPT_DIR/../.github/actions/setup-buildx-resilient/action.yml"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Extract the pre-pull step's `run: |` block verbatim from the action ---
+# The block starts after the first "run: |" and ends at the next less-indented
+# YAML key ("    - name:"). We dedent by the script's own indentation.
+ruby >"$WORK/prepull.sh" <<RUBY
+text = File.read("$ACTION", encoding: "UTF-8")
+lines = text.lines
+start = lines.index { |l| l =~ /^\s*run: \|\s*$/ }
+raise "could not find 'run: |' in action.yml" unless start
+body = []
+indent = nil
+lines[(start + 1)..].each do |line|
+  # Stop at the next step (a "- name:" at 4-space indent) or any key at <=4 indent.
+  break if line =~ /^\s{0,4}- name:/
+  if line.strip.empty?
+    body << "\n"
+    next
+  end
+  indent ||= line[/^\s*/].length
+  body << line[indent..]
+end
+print body.join
+RUBY
+
+if [ ! -s "$WORK/prepull.sh" ]; then
+  echo "FAIL: could not extract pre-pull script from action.yml"
+  exit 1
+fi
+
+# --- Mock docker on PATH; records calls, fails canonical/mirror per fixture ---
+mkdir -p "$WORK/bin"
+cat >"$WORK/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+# Fixtures (env): CANONICAL_OK / MIRROR_OK = 1 means that source serves pulls.
+echo "$*" >> "$DOCKER_CALLS"
+case "$1" in
+  pull)
+    ref="$2"
+    case "$ref" in
+      mirror.gcr.io/*)
+        [ "${MIRROR_OK:-0}" = "1" ] && { echo "$ref" >> "$DOCKER_PULLED"; exit 0; }
+        echo 'Error response from daemon: Get "https://mirror.gcr.io/v2/": timeout' >&2
+        exit 1 ;;
+      *)
+        [ "${CANONICAL_OK:-0}" = "1" ] && { echo "$ref" >> "$DOCKER_PULLED"; exit 0; }
+        echo 'Error response from daemon: Get "https://registry-1.docker.io/v2/": timeout' >&2
+        exit 1 ;;
+    esac ;;
+  tag)
+    echo "tag $2 $3" >> "$DOCKER_TAGGED"; exit 0 ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$WORK/bin/docker"
+
+PASS=0
+FAIL=0
+check() { # check <desc> <condition-cmd...>
+  local desc="$1"; shift
+  if "$@"; then echo "  ok: $desc"; PASS=$((PASS + 1)); else echo "  FAIL: $desc"; FAIL=$((FAIL + 1)); fi
+}
+
+run_case() { # run_case <name> <canonical_ok> <mirror_ok>
+  local name="$1" canonical="$2" mirror="$3"
+  export DOCKER_CALLS="$WORK/calls.$name"
+  export DOCKER_PULLED="$WORK/pulled.$name"
+  export DOCKER_TAGGED="$WORK/tagged.$name"
+  : >"$DOCKER_CALLS"; : >"$DOCKER_PULLED"; : >"$DOCKER_TAGGED"
+  set +e
+  PATH="$WORK/bin:$PATH" \
+    BUILDKIT_IMAGE="moby/buildkit:buildx-stable-1" \
+    REGISTRY_MIRROR="mirror.gcr.io" \
+    VERBOSE="false" \
+    PREPULL_ATTEMPTS="2" PREPULL_DELAY="1" \
+    CANONICAL_OK="$canonical" MIRROR_OK="$mirror" \
+    bash "$WORK/prepull.sh" >"$WORK/out.$name" 2>&1
+  echo $? >"$WORK/rc.$name"
+  set -e
+}
+
+echo "== Case 1: canonical Docker Hub healthy =="
+run_case canon 1 0
+check "exits 0" test "$(cat "$WORK/rc.canon")" = "0"
+check "pulled canonical image" grep -qx "moby/buildkit:buildx-stable-1" "$WORK/pulled.canon"
+check "did NOT touch the mirror" bash -c '! grep -q mirror.gcr.io "$1"' _ "$WORK/calls.canon"
+check "did NOT need to tag" test ! -s "$WORK/tagged.canon"
+
+echo "== Case 2: Docker Hub down, mirror healthy (issue #100 scenario) =="
+run_case mirror 0 1
+check "exits 0 (recovered via mirror)" test "$(cat "$WORK/rc.mirror")" = "0"
+check "pulled from mirror" grep -qx "mirror.gcr.io/moby/buildkit:buildx-stable-1" "$WORK/pulled.mirror"
+check "re-tagged mirror image to canonical ref" grep -qx \
+  "tag mirror.gcr.io/moby/buildkit:buildx-stable-1 moby/buildkit:buildx-stable-1" "$WORK/tagged.mirror"
+
+echo "== Case 3: both canonical and mirror down =="
+run_case both 0 0
+# Non-fatal by design: the step must still exit 0 so buildx boot can try itself.
+check "exits 0 (non-fatal fall-through)" test "$(cat "$WORK/rc.both")" = "0"
+check "attempted the mirror before giving up" grep -q mirror.gcr.io "$WORK/calls.both"
+check "warned about full failure" grep -q "could not pre-pull" "$WORK/out.both"
+
+echo "== Static checks on action.yml =="
+check "declares registry-mirror input" grep -q "registry-mirror:" "$ACTION"
+check "defaults mirror to mirror.gcr.io" grep -q "default: 'mirror.gcr.io'" "$ACTION"
+check "supports verbose tracing" grep -q "set -x" "$ACTION"
+check "honours RUNNER_DEBUG" grep -q "RUNNER_DEBUG" "$ACTION"
+check "pins boot driver image" grep -q "driver-opts: image=" "$ACTION"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "All issue #100 buildx mirror-fallback checks passed."


### PR DESCRIPTION
## Summary

Fixes #100. The release run [27314587149](https://github.com/link-foundation/box/actions/runs/27314587149) had four red jobs, all tracing to a **single root cause**: Docker Hub's registry (`registry-1.docker.io`) was unreachable from one amd64 runner for ~2.5 minutes, so booting the buildx `docker-container` driver could not pull `moby/buildkit:buildx-stable-1`. That one failure cascaded:

| Job | Why it was red |
| --- | --- |
| `build-languages-amd64 (java)` | **root cause** — buildx boot pull timed out against Docker Hub |
| `build-dind-amd64 (java)` | cascade — `box-java:2.3.0-amd64: not found` (java's push never happened) |
| `build-dind-amd64 (full)` | cascade — `box:2.3.0-amd64: not found` (`docker-build-push` skipped because the java build failed) |
| `build-dind-arm64 (full)` | cascade — `box:2.3.0-arm64: not found` (same skip chain) |

Three of the four reds are downstream symptoms — the "false positives" the issue refers to. Eliminating the root cause removes all four together.

## Root cause

Issue #97 already added `setup-buildx-resilient`, which pre-pulls the BuildKit image with retries so the boot reuses a cached copy. But both the pre-pull **and** the boot pull only ever talk to Docker Hub, so a *full* (not intermittent) outage longer than the retry budget defeats it. Retrying the same unreachable host harder is the wrong lever.

## Fix

`setup-buildx-resilient` now seeds the BuildKit image from a **pull-through registry mirror on independent infrastructure** when Docker Hub is down:

1. Pull from Docker Hub with the existing 5× exponential-backoff retries (common blip case).
2. **New:** if that exhausts, pull `mirror.gcr.io/moby/buildkit:buildx-stable-1` (Google's public Docker Hub mirror) and `docker tag` it back to the canonical reference — the boot then finds it locally and never touches the failing registry.
3. If even the mirror fails, fall through to the prior behaviour (no worse than before).

Plus: an opt-in `verbose` input + automatic tracing under `RUNNER_DEBUG=1` (requirement: add debug output for next-iteration diagnosis), and a tunable retry budget for fast tests.

**Codebase-wide:** all 12 `Set up Docker Buildx` steps in `release.yml` route through this one composite action, so every build job — JS, essentials, every language, the full `box` image, both arch push jobs, and every dind variant — is hardened by the single edit. No other workflow boots buildx.

## Tests

`experiments/test-issue100-buildx-mirror-fallback.sh` extracts the **real** pre-pull script out of `action.yml` and drives it with a mock `docker`:

- canonical healthy → mirror never touched
- Docker Hub down / mirror healthy → recovers + re-tags (the issue #100 scenario)
- both down → non-fatal fall-through

```
PASS=15 FAIL=0
All issue #100 buildx mirror-fallback checks passed.
```

## Case study & template comparison (issue requirements)

- Deep case study with timeline, full requirement list, root-cause analysis, prior-art survey and verification: `docs/case-studies/issue-100/CASE-STUDY.md` (+ raw failed-job logs under `ci-logs/`, original issue, and `template-reports.md`).
- Compared all four pipeline templates. The **rust** and **js** templates boot buildx with no mirror fallback and share the defect; **python** and **csharp** don't use buildx. Reported upstream with reproducible example, workaround and suggested fix:
  - rust-…-template#69
  - js-…-template#75

## Release

Patch changeset added (`.changeset/issue-100-buildx-mirror-fallback.md`) so the next release run validates the fix end-to-end.
